### PR TITLE
Fixes Regression bug on PnP connection

### DIFF
--- a/MSCloudLoginAssistant.psm1
+++ b/MSCloudLoginAssistant.psm1
@@ -256,8 +256,12 @@ function Test-MSCloudLogin
             $Global:spoAdminUrl = Get-SPOAdminUrl;
             if ([string]::IsNullOrEmpty($ConnectionUrl))
             {
-                # If we haven't specified a ConnectionUrl, just make the connection URL the first root site collection in the tenant
-                $Global:ConnectionUrl = $Global:spoAdminUrl.Replace("-admin","")
+                # If we haven't specified a ConnectionUrl, just make the connection URL central admin
+                $Global:ConnectionUrl = $Global:spoAdminUrl
+            }
+            else
+            {
+                $Global:ConnectionUrl = $ConnectionUrl
             }
             Write-Verbose -Message "`$Global:ConnectionUrl is $Global:ConnectionUrl."
             $testCmdlet = "Get-PnPSite";


### PR DESCRIPTION
Pnp needs to connect to the ConnectionUrl passed, or to central admin by default