### PR TITLE
Fix for PnP MFA Auth flow

### DIFF
--- a/MSCloudLoginAssistant.psm1
+++ b/MSCloudLoginAssistant.psm1
@@ -368,7 +368,8 @@ function Test-MSCloudLogin
                 }
                 elseif ($_.Exception -like "*$exceptionStringMFA*" -or `
                         $_.Exception -like "*Sequence contains no elements*" -or `
-                        ($_.Exception -like "*System.Reflection.TargetInvocationException: Exception has been thrown*" -and $Platform -eq "PNP"))
+                        ($_.Exception -like "*System.Reflection.TargetInvocationException: Exception has been thrown*" -and $Platform -eq "PNP") -or `
+                        ($_.Exception -like "*or the web site does not support SharePoint Online credentials*" -and $Platform -eq "SharePointOnline"))
                 {
                     Write-Verbose -Message "The specified account is configured for Multi-Factor Authentication. Please re-enter your credentials."
                     Write-Host -ForegroundColor Green " - Prompting for credentials with MFA for $Platform"

--- a/MSCloudLoginAssistant.psm1
+++ b/MSCloudLoginAssistant.psm1
@@ -121,7 +121,18 @@ function Test-MSCloudLogin
                     while ($null -eq $Global:ExchangeOnlineSession)
                     {
                         Write-Verbose -Message "Creating new EXO Session"
-                        $Global:ExchangeOnlineSession = New-PSSession -Name 'ExchangeOnline' -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $O365Credential -Authentication Basic -AllowRedirection -ErrorAction SilentlyContinue
+
+                        try
+                        {
+                            $Global:ExchangeOnlineSession = New-PSSession -Name 'ExchangeOnline' -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $O365Credential -Authentication Basic -AllowRedirection -ErrorAction Stop
+                        }
+                        catch
+                        {
+                            if ($_ -like '*Connecting to remote server *Access is denied.*')
+                            {
+                                Throw "The provided account doesn't have admin access to Exchange Online."
+                            }
+                        }
 
                         if ($null -eq $Global:ExchangeOnlineSession)
                         {

--- a/MSCloudLoginAssistant.psm1
+++ b/MSCloudLoginAssistant.psm1
@@ -355,7 +355,9 @@ function Test-MSCloudLogin
                 {
                     throw  "Bad credentials were supplied"
                 }
-                elseif ($_.Exception -like "*$exceptionStringMFA*" -or $_.Exception -like "*Sequence contains no elements*")
+                elseif ($_.Exception -like "*$exceptionStringMFA*" -or `
+                        $_.Exception -like "*Sequence contains no elements*" -or `
+                        ($_.Exception -like "*System.Reflection.TargetInvocationException: Exception has been thrown*" -and $Platform -eq "PNP"))
                 {
                     Write-Verbose -Message "The specified account is configured for Multi-Factor Authentication. Please re-enter your credentials."
                     Write-Host -ForegroundColor Green " - Prompting for credentials with MFA for $Platform"


### PR DESCRIPTION
Pnp throws a generic error message when an MFA account is used to call connect-pnponline without the -UseWebLogin parameter. I've added a check to see if the platform is PnP, and check for the generic error pattern in order to "Assume" MFA is required.