### PR TITLE
Error handling for Security and Compliance

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -312,7 +312,7 @@ function Test-MSCloudLogin
                             try
                             {
                                 $InformationPreference = "Continue"
-                                Write-Information -Message "[$counter/10]Too many existing workspaces. Waiting an additional 60 seconds for sessions to free up."                            
+                                Write-Information -Message "[$counter/10] Too many existing workspaces. Waiting an additional 60 seconds for sessions to free up."                            
                                 Start-Sleep -Seconds 60
                                 $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName "Microsoft.Exchange" `
                                     -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid/ `


### PR DESCRIPTION
Added up to 10 retries (60 seconds wait) for Security and Compliance when all sessions are already in use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/15)
<!-- Reviewable:end -->
