### PR TITLE
Update MSCloudLoginAssistant.psm1

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -492,7 +492,8 @@ function Test-MSCloudLogin
     }
     catch
     {
-        if ($_.Exception -like "*$connectCmdlet*" -or $_.Exception -like "*The access token expiry*")
+        if ($_.Exception -like "*$connectCmdlet*" -or $_.Exception -like "*The access token expiry*" -or `
+            ($Platform -eq 'PnP' -and $_.Exception -like '*Microsoft.SharePoint.Client.ServerUnauthorizedAccessException*'))
         {
             Write-Debug -Message "Running '$testCmdlet' failed on initial attempt."
             try


### PR DESCRIPTION
There was an issue where the moment an issue was encountered using PnP (threshold hit), all subsequent calls where throwing false unauthorized errors. If those are thrown, we at least try to connect to Connect-PnPOnline to check for false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/20)
<!-- Reviewable:end -->
