### PR TITLE
Fix error with 1.0.3 with Connect-MicrosoftTeams

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -519,9 +519,9 @@ function Test-MSCloudLogin
             $RedirectURI = "https://teamscmdlet.microsoft.com";
             $connectCmdlet = "Connect-MicrosoftTeams";
             $connectCmdletArgs = "-Credential `$Global:o365Credential";
-            #$connectCmdletMfaRetryArgs = "-AadAccessToken `$AuthToken -AccountId `$Global:o365Credential.UserName";
             $connectCmdletMfaRetryArgs = "-AccountId `$Global:o365Credential.UserName";
             $variablePrefix = "teams"
+            Import-Module MicrosoftTeams -Force
         }
         'SkypeForBusiness'
         {


### PR DESCRIPTION
As weird as it sounds, this is not related to the previous Skype for Business PR, but to the upgrade to MicrosoftTeams 1.0.3 which now complains about a missing Connect-MicrosoftTeams cmdlet. The fix is to implicitly load the module within the switch case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/28)
<!-- Reviewable:end -->
