### PR TITLE
Application identity authentication

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
@@ -3,17 +3,30 @@ function Connect-MSCloudLoginAzure
     [CmdletBinding()]
     param()
     try
-    {
-        if ($null -ne $Global:o365Credential)
+    {        
+        if (!$Global:UseApplicationIdentity -and $null -ne $Global:o365Credential)
         {
-            Connect-AzAccount -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
-            $Global:MSCloudLoginAzureConnected = $True
+            Connect-AzAccount -Credential $Global:o365Credential -ErrorAction Stop | Out-Null            
+        }        
+        elseif ($Global:UseApplicationIdentity)
+        {
+            if($Global:appIdentityParams.CertificateThumbprint) 
+            {
+                Connect-AzAccount -ApplicationId $Global:appIdentityParams.AppId -Tenant $Global:appIdentityParams.Tenant -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint  -ErrorAction Stop | Out-Null
+                Write-Verbose "Connected to Azure using application identity with certificate thumbprint"            
+            }
+            else
+            {
+                Connect-AzAccount -Credential $Global:appIdentityParams.ServicePrincipalCredentials -Tenant $Global:appIdentityParams.Tenant -ServicePrincipal  -ErrorAction Stop | Out-Null
+                Write-Verbose "Connected to Azure using application identity with application secret"            
+            }
         }
         else
         {
             Connect-AzAccount -ErrorAction Stop | Out-Null
-            $Global:MSCloudLoginAzureConnected = $True
         }
+        
+        $Global:MSCloudLoginAzureConnected = $True
     }
     catch 
     {

--- a/Modules/MSCloudLoginAssistant/Workloads/AzureAD.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/AzureAD.psm1
@@ -4,7 +4,25 @@ function Connect-MSCloudLoginAzureAD
     param()
     try 
     {
-        Connect-AzureAD -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
+        if ($Global:UseApplicationIdentity)
+        {
+            if($Global:appIdentityParams.CertificateThumbprint) 
+            {
+                Connect-AzureAD -TenantId $Global:appIdentityParams.Tenant -ApplicationId $Global:appIdentityParams.AppId -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint -ErrorAction Stop | Out-Null            
+                Write-Verbose "Connected to AzureAD using application identity with certificate thumbprint"            
+            }
+            else
+            {                
+                # actually it probably can do so by getting the access token manually, but for now we want it to work with the certificate
+                throw "The AzureAD Platform does not support connecting with application secret"
+            }            
+        }
+        else
+        {
+            Connect-AzureAD -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
+            Write-Verbose "Connected to AzureAD using regular authentication"
+        }
+        
         $Global:IsMFAAuth = $false
         $Global:MSCloudLoginAzureADConnected = $true
     }

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -2,6 +2,11 @@ function Connect-MSCloudLoginExchangeOnline
 {
     [CmdletBinding()]
     param()
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The Exchange Platform does not support connecting with application identity."
+    }
+    
     if ($null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"

--- a/Modules/MSCloudLoginAssistant/Workloads/MSOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MSOnline.psm1
@@ -2,7 +2,11 @@ function Connect-MSCloudLoginMSOnline
 {
     [CmdletBinding()]
     param()
-
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The MSOnline Platform does not support connecting with application identity."
+    }
+    
     if ($null -ne $Global:o365Credential)
     {
         Test-MSCloudLogin -Platform AzureAD -CloudCredential $Global:o365Credential

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -41,7 +41,7 @@ function Connect-MSCloudLoginPnP
             }
             else
             {
-                Connect-PnPOnline -Url $Global:SPOConnectionUrl -Tenant $Global:appIdentityParams.Tenant -AppId $Global:appIdentityParams.AppId -AppSecret $Global:appIdentityParams.AppSecret
+                Connect-PnPOnline -Url $Global:SPOConnectionUrl -AppId $Global:appIdentityParams.AppId -AppSecret $Global:appIdentityParams.AppSecret
                 Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using application identity with application secret"            
             }
         }

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -9,14 +9,19 @@ function Connect-MSCloudLoginPnP
     $clientid = "9bc3ab49-b65d-410a-85ad-de819febfddc"
     $RedirectURI = "https://oauth.spops.microsoft.com/"
 
-    if ($null -eq $Global:o365Credential)
+    if (!$Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"
     }
 
     if ([string]::IsNullOrEmpty($ConnectionUrl) -and [string]::IsNullOrEmpty($Global:SPOAdminUrl))
-    {
-        $Global:SPOAdminUrl = Get-SPOAdminUrl -CloudCredential $Global:o365Credential
+    {        
+        $Global:SPOAdminUrl = Get-SPOAdminUrl -CloudCredential $Global:o365Credential `
+                    -AppId $Global:appIdentityParams.AppId `
+                    -AppSecret $Global:appIdentityParams.AppSecret `
+                    -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint `
+                    -Tenant $Global:appIdentityParams.Tenant
+                    
         $Global:SPOConnectionUrl = $Global:SPOAdminUrl
     }
     else
@@ -27,8 +32,25 @@ function Connect-MSCloudLoginPnP
 
     try
     {
-        Connect-PnPOnline -Url $Global:SPOConnectionUrl -Credentials $Global:o365Credential
-        Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using regular authentication"
+        if($Global:UseApplicationIdentity)
+        {
+            if($Global:appIdentityParams.CertificateThumbprint)
+            {
+                Connect-PnPOnline -Url $Global:SPOConnectionUrl -Tenant $Global:appIdentityParams.Tenant -ClientId $Global:appIdentityParams.AppId -Thumbprint $Global:appIdentityParams.CertificateThumbprint
+                Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using application identity with certificate thumbprint"            
+            }
+            else
+            {
+                Connect-PnPOnline -Url $Global:SPOConnectionUrl -Tenant $Global:appIdentityParams.Tenant -AppId $Global:appIdentityParams.AppId -AppSecret $Global:appIdentityParams.AppSecret
+                Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using application identity with application secret"            
+            }
+        }
+        else
+        {
+            Connect-PnPOnline -Url $Global:SPOConnectionUrl -Credentials $Global:o365Credential
+            Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using regular authentication"
+        }
+
         $Global:IsMFAAuth = $false
     }
     catch

--- a/Modules/MSCloudLoginAssistant/Workloads/PowerPlatform.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PowerPlatform.psm1
@@ -2,6 +2,10 @@ function Connect-MSCloudLoginPowerPlatform
 {
     [CmdletBinding()]
     param()
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The PowerPlatforms Platform does not support connecting with application identity."
+    }
 
     try
     {

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -2,6 +2,11 @@ function Connect-MSCloudLoginSecurityCompliance
 {
     [CmdletBinding()]
     param()
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The SecurityComplianceCenter Platform does not support connecting with application identity."
+    }
+    
     if ($null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"

--- a/Modules/MSCloudLoginAssistant/Workloads/SharePointOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SharePointOnline.psm1
@@ -2,9 +2,13 @@ function Connect-MSCloudLoginSharePointOnline
 {
     [CmdletBinding()]
     param()
-
-    try
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
     {
+        throw "The SharePointOnline Platform does not support connecting with application identity."
+    }
+    
+    try
+    {        
         if ($null -ne $Global:o365Credential)
         {
             if ([string]::IsNullOrEmpty($ConnectionUrl))

--- a/Modules/MSCloudLoginAssistant/Workloads/SkypeForBusiness.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SkypeForBusiness.psm1
@@ -2,7 +2,11 @@ function Connect-MSCloudLoginSkypeForBusiness
 {
     [CmdletBinding()]
     param()
-
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The SkypeForBusiness Platform does not support connecting with application identity."
+    }
+    
     if ($null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
@@ -3,7 +3,18 @@ function Connect-MSCloudLoginTeams
     [CmdletBinding()]
     param()
 
-    if ($null -ne $Global:o365Credential)
+    if ($Global:UseApplicationIdentity)
+    {    
+        if($Global:appIdentityParams.CertificateThumbprint) 
+        {
+            Connect-MicrosoftTeams -TenantId $Global:appIdentityParams.Tenant -ApplicationId $Global:appIdentityParams.AppId -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint -ErrorAction Stop | Out-Null                
+        }
+        else
+        {
+            throw "The MicrosoftTeams Platform does not support connecting with application secret"
+        }
+    }
+    elseif ($null -ne $Global:o365Credential)
     {
         if ($Global:o365Credential.UserName.Split('@')[1] -like '*.de')
         {


### PR DESCRIPTION
This pull request adds support for application identity authentication on workloads where such a thing is possible.
It is closely related to our efforts of using Office365DSC from within a service without human interaction when MFA is used on the tenant.


When only the application identity parameters are used on workloads that do not support them, I chose to throw an error to alert the user to the fact since he may not be aware of it, I did not want it to automatically fallback since it's expected to work without human interaction.
On the other hand, if the CloudCredential parameter is supplied then the workloads that do not support application identity will fallback to the default behaviour, including possible MFA prompts. 

For some reason PnP does not work correctly when using the application secret method. It connects normally but no commands will work. I left the logic as is since it should work from the documentation. Hoping it's something transient.

Our plan for Office365DSC is to use a certificate with a combination of an app password(Exchange and SC seem to work with it ok, Sfb not so much).
There are still unknowns regarding Sfb but this PR would take out a large chunk of doing an Office365DSC extraction from within a service.
  
I tried writing some tests but it proved  difficult because I'm not sure how it should work withing VSCode, and also because of the $global: stuff. The tests are also failing currently, broken window broken and all that :).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/40)
<!-- Reviewable:end -->
