### PR TITLE
Fix for PnP connection

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -14,9 +14,16 @@ function Connect-MSCloudLoginPnP
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"
     }
 
-    if ([string]::IsNullOrEmpty($ConnectionUrl) -and [string]::IsNullOrEmpty($Global:SPOAdminUrl))
+    if ([string]::IsNullOrEmpty($ConnectionUrl))
     {
-        $Global:SPOAdminUrl = Get-SPOAdminUrl -CloudCredential $Global:o365Credential
+        if (-not [string]::IsNullOrEmpty($Global:SPOAdminUrl))
+        {
+            $Global:SPOConnectionUrl = $Global:SPOAdminUrl
+        }
+        else
+        {
+            $Global:SPOAdminUrl = Get-SPOAdminUrl -CloudCredential $Global:o365Credential
+        }
         $Global:SPOConnectionUrl = $Global:SPOAdminUrl
     }
     else


### PR DESCRIPTION
Fixes an issue where if you tried connecting to PnP right after connecting to Security and Compliance, then PnP tries to call Connect-PnPService with an empty URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/42)
<!-- Reviewable:end -->
