### PR TITLE
Remove mandatory Environment name for Teams with MFA

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
@@ -51,7 +51,7 @@ function Connect-MSCloudLoginTeams
             }
             elseif ($_.Exception -like '*AADSTS50076*')
             {
-                Connect-MSCloudLoginTeamsMFA
+                Connect-MSCloudLoginTeamsMFA -EnvironmentName $Global:CloudEnvironment
             }
             else
             {
@@ -80,7 +80,7 @@ function Connect-MSCloudLoginTeamsMFA
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $EnvironmentName
     )


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/43)
<!-- Reviewable:end -->
