### PR TITLE
Quick update to Azure.psm1

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.0.10'
+    ModuleVersion          = '1.0.11'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
@@ -156,7 +156,7 @@ function Connect-MSCloudLoginAzure
                     throw " - Please select *only one* subscription."
                 }
                 Write-Host -ForegroundColor White " - Setting active subscription to '$($Global:subscriptionDetails.Name)'..."
-                Set-AzContext -Subscription $Global:subscriptionDetails.Id
+                Set-AzContext -Subscription $Global:subscriptionDetails.Id -Name $Global:subscriptionDetails.Name -Force
             }
         }
     }


### PR DESCRIPTION
Set-AzContext now also uses sub name as sometimes wrong one being set
Increment version for gallery to 1.0.11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/60)
<!-- Reviewable:end -->
