### PR TITLE
Fixed issue with MFA enabled accounts and PNP

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.0.41'
+    ModuleVersion          = '1.0.42'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -111,11 +111,12 @@ function Connect-MSCloudLoginPnP
             Write-Verbose "Connected to PnP {$($Global:SPOConnectionUrl) using regular authentication"
             $Global:IsMFAAuth = $false
         }
-    }
-    catch
+   }
+catch
     {
         if ($_.Exception -like '*Microsoft.SharePoint.Client.ServerUnauthorizedAccessException*' -or `
-                $_.Exception -like '*The remote server returned an error: (401) Unauthorized.*')
+                $_.Exception -like '*The remote server returned an error: (401) Unauthorized.*' -or `
+                $_.Exception -like '*Object reference not set to an instance of an object*')
         {
             try
             {
@@ -180,5 +181,6 @@ function Connect-MSCloudLoginPnP
             }
         }
     }
+
     return
 }


### PR DESCRIPTION
PNP now throws a different error message if you don't specify -useweblogin and use a MFA enabled account

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/92)
<!-- Reviewable:end -->
