### PR TITLE
Fix for extract of SCC resources

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.0.48'
+    ModuleVersion          = '1.0.49'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -29,14 +29,17 @@ function Connect-MSCloudLoginSecurityCompliance
     $VerbosePreference = "Continue"
     $WarningPreference = 'SilentlyContinue'
     $ProgressPreference = 'SilentlyContinue'
-    [array]$activeSessions = Get-PSSession | Where-Object -FilterScript {$_.ComputerName -like '*.ps.compliance.protection*' -and $_.State -eq 'Opened'}
+    [array]$activeSessions = Get-PSSession | Where-Object -FilterScript { $_.ComputerName -like '*.ps.compliance.protection*' -and $_.State -eq 'Opened' }
     Write-Verbose "$(Get-Runspace | Out-String)"
-    [array] $opened = Get-Runspace | Where-Object -FilterScript {$_.RunspaceAvailability -eq 'Available'}
-    for ($i = 1; $i -lt $opened.Length; $i++)
+    [array] $opened = Get-Runspace | Where-Object -FilterScript { $_.RunspaceAvailability -eq 'Available' }
+    if ($SkipModuleReload -eq $false)
     {
-        Write-Verbose "Closing runspace $($opened[$i].Name)"
-        $opened[$i].Close()
-        $opened[$i].Dispose()
+        for ($i = 1; $i -lt $opened.Length; $i++)
+        {
+            Write-Verbose "Closing runspace $($opened[$i].Name)"
+            $opened[$i].Close()
+            $opened[$i].Dispose()
+        }
     }
     if ($activeSessions.Length -ge 1 -and $SkipModuleReload -eq $true)
     {
@@ -62,15 +65,18 @@ function Connect-MSCloudLoginSecurityCompliance
 
     switch ($Global:CloudEnvironmentInfo.cloud_instance_name)
     {
-        "microsoftonline.com" {
+        "microsoftonline.com"
+        {
             $ConnectionUrl = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
             $AuthorizationUrl = 'https://login.microsoftonline.com/common'
         }
-        "microsoftonline.us" {
+        "microsoftonline.us"
+        {
             $ConnectionUrl = 'https://ps.compliance.protection.office365.us/powershell-liveid/'
             $AuthorizationUrl = 'https://login.microsoftonline.us/common'
         }
-        "microsoftonline.de" {
+        "microsoftonline.de"
+        {
             $ConnectionUrl = 'https://ps.compliance.protection.outlook.de/powershell-liveid/'
             $AuthorizationUrl = 'https://login.microsoftonline.de/common'
         }
@@ -80,8 +86,8 @@ function Connect-MSCloudLoginSecurityCompliance
     #endregion
 
     if (-not [String]::IsNullOrEmpty($ApplicationId) -and `
-        -not [String]::IsNullOrEmpty($TenantId) -and `
-        -not [String]::IsNullOrEmpty($CertificateThumbprint))
+            -not [String]::IsNullOrEmpty($TenantId) -and `
+            -not [String]::IsNullOrEmpty($CertificateThumbprint))
     {
         Write-Verbose -Message "Attempting to connect to Security and Compliance using AAD App {$ApplicationID}"
         try
@@ -125,15 +131,15 @@ function Connect-MSCloudLoginSecurityComplianceMFA
 {
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
         $CloudCredential,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $ConnectionUrl,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $AuthorizationUrl
     )


### PR DESCRIPTION
Export of SCSensitivityLabels was failing because runspaces were closed. Added a check for SkipModuleReload and it resolved issue can export resources as well as run apply config with multiple resources within SCC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/104)
<!-- Reviewable:end -->
