### PR TITLE
Fixed check for active sessions in Security & Compliance

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -29,7 +29,6 @@ function Connect-MSCloudLoginSecurityCompliance
     $VerbosePreference = "Continue"
     $WarningPreference = 'SilentlyContinue'
     $ProgressPreference = 'SilentlyContinue'
-    [array]$activeSessions = Get-PSSession | Where-Object -FilterScript {$_.ComputerName -like '*.ps.compliance.protection*' -and $_.State -eq 'Opened'}
     Write-Verbose "$(Get-Runspace | Out-String)"
     [array] $opened = Get-Runspace | Where-Object -FilterScript {$_.RunspaceAvailability -eq 'Available'}
     for ($i = 1; $i -lt $opened.Length; $i++)
@@ -38,6 +37,7 @@ function Connect-MSCloudLoginSecurityCompliance
         $opened[$i].Close()
         $opened[$i].Dispose()
     }
+    [array]$activeSessions = Get-PSSession | Where-Object -FilterScript {$_.ComputerName -like '*.ps.compliance.protection*' -and $_.State -eq 'Opened'}
     if ($activeSessions.Length -ge 1 -and $SkipModuleReload -eq $true)
     {
         Write-Verbose -Message "Found {$($activeSessions.Length)} existing Security and Compliance Session"


### PR DESCRIPTION
The `ActiveSessions[0]` might have been closed by the loop after.
This caused an error while trying to use `Import-PSSession` on an already closed and disposed session.

To fix this, just check for active sessions after closing the already open connections