### PR TITLE
Fixes MFA login in SkypeForBusiness

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/SkypeForBusiness.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SkypeForBusiness.psm1
@@ -58,7 +58,7 @@ function Connect-MSCloudLoginSkypeForBusiness
             }
             Import-Module $Global:SkypeModule -Global @IPMOParameters | Out-Null
         }
-        if ($_.Exception -like '*unknown_user_type: Unknown User Type*')
+        elseif ($_.Exception -like '*unknown_user_type: Unknown User Type*')
         {
             $Global:CloudEnvironment = 'GCCHigh'
 


### PR DESCRIPTION
The connection would always fail on the first connection since it throws the error caused by connection needing MFA.