### PR TITLE
SecurityCompliance: Removed verbose being  set to continue

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -26,7 +26,6 @@ function Connect-MSCloudLoginSecurityCompliance
         [System.Boolean]
         $SkipModuleReload = $false
     )
-    $VerbosePreference = "Continue"
     $WarningPreference = 'SilentlyContinue'
     $ProgressPreference = 'SilentlyContinue'
 


### PR DESCRIPTION
This cause a lot of unwanted noise when verbose output is not wanted.
By removing it, the user can decide if they want verbose output or not with `-Verbose` parameter