### PR TITLE
Fix for SCC and MFA enabled account

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.0.62'
+    ModuleVersion          = '1.0.63'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -111,7 +111,7 @@ function Connect-MSCloudLoginSecurityCompliance
         catch
         {
             Write-Verbose -Message "Could not connect connect IPPSSession with Credentials: {$($_.Exception)}"
-            Connect-MSCloudLoginSecurityComplianceMFA -CloudCredential $Global:o365Credential `
+            Connect-MSCloudLoginSecurityComplianceMFA -Credential $Global:o365Credential `
                 -ConnectionUrl $ConnectionUrl `
                 -AuthorizationUrl $AuthorizationUrl
         }

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -143,9 +143,17 @@ function Connect-MSCloudLoginSecurityComplianceMFA
         $VerbosePreference = "SilentlyContinue"
         $InformationPreference = "SilentlyContinue"
         $WarningPreference = "SilentlyContinue"
-        Connect-IPPSSession -UserPrincipalName $Credential.UserName `
-            -ConnectionUri $ConnectionUrl `
-            -AzureADAuthorizationEndpointUri $AuthorizationUrl -Verbose:$false | Out-Null
+        if ($Global:CloudEnvironmentInfo.cloud_instance_name -eq "microsoftonline.com")
+        {
+            Connect-IPPSSession -UserPrincipalName $Credential.UserName `
+                 -Verbose:$false | Out-Null
+        }
+        else
+        {
+            Connect-IPPSSession -UserPrincipalName $Credential.UserName `
+                -ConnectionUri $ConnectionUrl `
+                -Verbose:$false | Out-Null
+        }
         $VerbosePreference = $CurrentVerbosePreference
         $InformationPreference = $CurrentInformationPreference
         $WarningPreference = $CurrentWarningPreference


### PR DESCRIPTION
Fix parameter mismatch and changes to login for MFA enabled accounts - https://docs.microsoft.com/en-us/powershell/exchange/connect-to-scc-powershell?view=exchange-ps#connect-to-security--compliance-powershell-using-mfa-and-modern-authentication 