### PR TITLE
Added more detection and proper logging for DeviceCode errors

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -47,8 +47,16 @@ function Connect-MSCloudLoginPnP
             if ($Global:MSCloudLoginConnectionProfile.PnP.AuthenticationType -eq 'Credentials' -and `
                 -not $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl)
             {
-                $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl      = Get-SPOAdminUrl -Credential $Global:MSCloudLoginConnectionProfile.PnP.Credentials
-                $Global:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl
+                $adminUrl = Get-SPOAdminUrl -Credential $Global:MSCloudLoginConnectionProfile.PnP.Credentials
+                if ([String]::IsNullOrEmpty($adminUrl) -eq $false)
+                {
+                    $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl      = $adminUrl
+                    $Global:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl
+                }
+                else
+                {
+                    throw "Unable to retrieve SharePoint Admin Url. Check if the Graph can be contacted successfully."
+                }
             }
             else
             {


### PR DESCRIPTION
This PR adds better detection and logging for Device Code authentication requests. In non-interactive sessions, requesting a Device Code logon doesn't make sense and just adds additional waiting time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/118)
<!-- Reviewable:end -->
