### PR TITLE
Add MSI support for MSGraph

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
@@ -53,7 +53,7 @@ class MSCloudLoginConnectionProfile
 class Workload
 {
     [string]
-    [ValidateSet('Credentials', 'CredentialsWithApplicationId', 'ServicePrincipalWithSecret', 'ServicePrincipalWithThumbprint', 'ServicePrincipalWithPath', 'Interactive')]
+    [ValidateSet('Credentials', 'CredentialsWithApplicationId', 'ServicePrincipalWithSecret', 'ServicePrincipalWithThumbprint', 'ServicePrincipalWithPath', 'Interactive', 'Identity')]
     $AuthenticationType
 
     [boolean]
@@ -146,6 +146,10 @@ class Workload
         elseif ($this.Credentials)
         {
             $this.AuthenticationType = 'Credentials'
+        }
+        elseif ($this.Identity) 
+        {
+            $this.AuthenticationType = 'Identity'
         }
         else
         {
@@ -306,6 +310,9 @@ class MicrosoftGraph:Workload
 
     [string]
     $UserTokenUrl
+
+    [switch]
+    $Identity
 
     MicrosoftGraph()
     {

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -138,6 +138,10 @@ function Connect-M365Tenant
         $SkipModuleReload = $false,
 
         [Parameter()]
+        [Switch]
+        $Identity,
+
+        [Parameter()]
         [System.String]
         [ValidateSet("v1.0", "beta")]
         $ProfileName = "v1.0"
@@ -203,6 +207,7 @@ function Connect-M365Tenant
             $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId              = $TenantId
             $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.CertificateThumbprint = $CertificateThumbprint
             $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ProfileName           = $ProfileName
+            $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Identity              = $Identity
             $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connect()
         }
         'MicrosoftTeams'

--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
@@ -42,6 +42,19 @@ function Connect-MSCloudLoginMicrosoftGraph
         Write-Verbose -Message "Will try connecting with user credentials"
         Connect-MSCloudLoginMSGraphWithUser
     }
+    elseif ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType -eq 'Identity')
+    {
+        Write-Verbose "Connecting with managed identity"
+        $AzProfile = Login-AzAccount -Identity
+        $accessToken = (Get-AzAccessToken -ResourceTypeName MSGraph).Token
+        $null = Logout-AzAccount -Username $AzProfile.Context.Account
+
+        Connect-MgGraph -AccessToken $accessToken
+        $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
+        $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $true
+        $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
+        $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId = (Get-MGContext).TenantId
+    }
     else
     {
         try


### PR DESCRIPTION
Add support for VM MSI using Login-AzAccount -Identity and Get-AzAccessToken -ResourceTypeName MSGraph.  This could be extended to AzureAD and Azure using same pattern

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/123)
<!-- Reviewable:end -->
