### PR TITLE
Add Service Principal with Certrificate Authentication methods for Security and Compliance Center

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
@@ -81,7 +81,7 @@ class Workload
     [string]
     $TenantId
 
-    [string]
+    [securestring]
     $CertificatePassword
 
     [string]
@@ -399,7 +399,7 @@ class PnP:Workload
                 -not[String]::IsNullOrEmpty($this.CertificatePath))
         )
         {
-            throw 'Cannot specific both a Certificate Thumbprint and Certificate Path and Password'
+            throw 'Cannot specify both a Certificate Thumbprint and Certificate Path and Password'
         }
     }
 

--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
@@ -155,7 +155,7 @@ class Workload
         }
         elseif ($this.ApplicationId -and $this.TenantId -and $this.CertificatePath -and $this.CertificatePassword)
         {
-            $this.AuthenticationType = 'ServicePrincipalWithPAth'
+            $this.AuthenticationType = 'ServicePrincipalWithPath'
         }
         elseif ($this.Credentials -and $this.ApplicationId)
         {

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.0.95'
+    ModuleVersion          = '1.0.96'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.psm1
@@ -200,11 +200,11 @@ function Connect-MSCloudLoginPnP
         {
             if ($Url)
             {
-                $connectionURL = $Url
+                $connectionURL = $Global:MSCloudLoginConnectionProfile.PnP.ConnectionUrl
             }
             else
             {
-                $connectionURL = $Global:MSCloudLoginConnectionProfile.PnP.ConnectionUrl
+                $connectionURL = $Global:MSCloudLoginConnectionProfile.PnP.AdminUrl
             }
 
 

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -62,8 +62,10 @@ function Connect-MSCloudLoginSecurityCompliance
         Write-Verbose -Message "Attempting to connect to Security and Compliance using AAD App {$($Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationID)}"
         try
         {
-            # TODO - When Security & Compliance supports CBA
-            throw "Security and COmpliance doesn't yet support authenticating with a Service Principal"
+            Write-Verbose -Message "Connecting to Security & Compliance with Service Principal and Certificate Thumbprint"
+            Connect-IPPSSession -AppId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationId `
+                -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificateThumbprint `
+                -Organization $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId
         }
         catch
         {

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -66,6 +66,9 @@ function Connect-MSCloudLoginSecurityCompliance
             Connect-IPPSSession -AppId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationId `
                 -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificateThumbprint `
                 -Organization $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.ToString()
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.MultiFactorAuthentication = $false
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected                 = $true
         }
         catch
         {
@@ -82,6 +85,9 @@ function Connect-MSCloudLoginSecurityCompliance
                 -CertificateFilePath $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificatePath `
                 -Organization $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId `
                 -CertificatePassword $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificatePassword
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.ToString()
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.MultiFactorAuthentication = $false
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected                 = $true
         }
         catch
         {
@@ -98,7 +104,7 @@ function Connect-MSCloudLoginSecurityCompliance
                 -ConnectionUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectionUrl `
                 -AzureADAuthorizationEndpointUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthorizationUrl `
                 -Verbose:$false -ErrorAction Stop | Out-Null
-            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.TOString()
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.ToString()
             $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.MultiFactorAuthentication = $false
             $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected                 = $true
         }
@@ -133,7 +139,7 @@ function Connect-MSCloudLoginSecurityComplianceMFA
                 -Verbose:$false | Out-Null
         }
         Write-Verbose -Message "New Session with MFA created successfully"
-        $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.TOString()
+        $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime         = [System.DateTime]::Now.ToString()
         $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.MultiFactorAuthentication = $false
         $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected                 = $true
     }

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -71,6 +71,9 @@ function Connect-MSCloudLoginSecurityCompliance
             throw $_
         }
     }
+    elseif ($Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthenticationType -eq 'ServicePrincipalWithPath') {
+        <# Action when this condition is true #>
+    }
     else
     {
         try

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -72,7 +72,20 @@ function Connect-MSCloudLoginSecurityCompliance
         }
     }
     elseif ($Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthenticationType -eq 'ServicePrincipalWithPath') {
-        <# Action when this condition is true #>
+
+        try
+        {
+            Write-Verbose -Message "Connecting to Security & Compliance with Service Principal and Certificate Path"
+            Connect-IPPSSession -AppId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationId `
+                -CertificateFilePath $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificatePath `
+                -Organization $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId `
+                -CertificatePassword $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificatePassword
+        }
+        catch
+        {
+            $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected = $false
+            throw $_
+        }
     }
     else
     {


### PR DESCRIPTION
EXO V3 supports now the certificate-based authentication to Security & Compliance PowerShell, both with thumbprint and certificate path: https://learn.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps#connection-examples

I have added both authentication types to the workload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/133)
<!-- Reviewable:end -->
