### PR TITLE
Fixes #134 - Connect-MSCloudLoginMSGraphWithUser missing profile parameters

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
@@ -192,7 +192,9 @@ function Connect-MSCloudLoginMSGraphWithUser
             try
             {
                 Connect-MgGraph -Environment $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment `
-                    -Scopes 'Domain.Read.All' -ErrorAction 'Stop' | Out-Null
+                    -TenantId $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId `
+                    -ClientId $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId `
+                    -Scopes .default -ErrorAction 'Stop' | Out-Null
                 $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
             }
             catch
@@ -206,7 +208,9 @@ function Connect-MSCloudLoginMSGraphWithUser
 
                     New-Item $path -Force | Out-Null
                     Connect-MgGraph -Environment $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment `
-                        -Scopes 'Domain.Read.All' | Out-Null
+                        -TenantId $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId `
+                        -ClientId $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId `
+                        -Scopes .default | Out-Null
                     $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
                 }
 


### PR DESCRIPTION
To support CredentialsWithApplicationId, adds missing TenantId and ClientId parameters to Connect-MgGraph connection command.

Changes requested Scopes to generic .default

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/mscloudloginassistant/135)
<!-- Reviewable:end -->
