### PR TITLE
Fix issue connecting to Graph using app secret

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
@@ -118,9 +118,6 @@ function Connect-MSCloudLoginMicrosoftGraph
                         -Environment $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment `
                         -Certificate $cert | Out-Null
                 }
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $false
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
             }
             else
             {
@@ -135,12 +132,11 @@ function Connect-MSCloudLoginMicrosoftGraph
                 {
                     throw $_
                 }
-
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $false
-                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
             }
 
+            $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
+            $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $false
+            $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
             Write-Verbose -Message 'Connected'
         }
         catch

--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.psm1
@@ -126,29 +126,19 @@ function Connect-MSCloudLoginMicrosoftGraph
             {
                 Request-MSGraphOauthToken
 
-                if (![String]::IsNullOrEmpty($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.AccessToken))
+                Write-Verbose -Message 'Connecting to Microsoft Graph'
+                try
                 {
-                    Write-Verbose -Message 'Connecting to Microsoft Graph'
-
-                    try
-                    {
-                        Connect-MgGraph -AccessToken $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.AccessToken | Out-Null
-                    }
-                    catch
-                    {
-                        throw $_
-                    }
-
-                    $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
-                    $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $false
-                    $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
+                    Connect-MgGraph -AccessToken $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.AccessToken | Out-Null
                 }
-                else
+                catch
                 {
-                    $Message = 'Could not acquire token to connect to Microsoft Graph, aborting'
-                    Write-Verbose -Message $Message
-                    throw $Message
+                    throw $_
                 }
+
+                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
+                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.MultiFactorAuthentication = $false
+                $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
             }
 
             Write-Verbose -Message 'Connected'
@@ -194,7 +184,9 @@ function Request-MSGraphOauthToken
     }
     else
     {
-        $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.AccessToken = $null
+        $Message = 'Could not acquire token to connect to Microsoft Graph, aborting'
+        Write-Verbose -Message $Message
+        throw $Message
     }
 }
 


### PR DESCRIPTION
Currently it's not possible to connect to Graph using app secret since it tries to convert the token to SecureString twice, this PR fixes that and also sprinkles some error handling around.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/169)
<!-- Reviewable:end -->
