### PR TITLE
Fix security compliance

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -83,7 +83,6 @@ function Connect-MSCloudLoginSecurityCompliance
                     -Organization $Global:MSCloudLoginConnectionProfile.OrganizationName `
                     -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificateThumbprint `
                     -ShowBanner:$false `
-                    -ShowProgress:$false `
                     -ConnectionUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.ConnectionUri `
                     -AzureADAuthorizationEndpointUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.AzureADAuthorizationEndpointUri `
                     -Verbose:$false `

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -85,8 +85,7 @@ function Connect-MSCloudLoginSecurityCompliance
                     -ShowBanner:$false `
                     -ConnectionUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.ConnectionUri `
                     -AzureADAuthorizationEndpointUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.AzureADAuthorizationEndpointUri `
-                    -Verbose:$false `
-                    -SkipLoadingCmdletHelp | Out-Null
+                    -Verbose:$false
                 $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime = [System.DateTime]::Now.ToString()
                 $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.MultiFactorAuthentication = $false
                 $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected = $true

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -70,15 +70,22 @@ function Connect-MSCloudLoginSecurityCompliance
             if ($null -ne $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints -and `
             $null -ne $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.ConnectionUri -and `
             $null -ne $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.AzureADAuthorizationEndpointUri)
+            if ($null -eq $Global:MSCloudLoginConnectionProfile.OrganizationName)
+            {
+                $Global:MSCloudLoginConnectionProfile.OrganizationName = Get-MSCloudLoginOrganizationName `
+                    -ApplicationId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationId `
+                    -TenantId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId `
+                    -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificateThumbprint
+            }
             {
                 Write-Verbose -Message "Connecting by endpoints URI"
-                Connect-IPPSSession -AppId $Global:MSCloudLoginConnectionProfile.ExchangeOnline.ApplicationId `
+                Connect-IPPSSession -AppId $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ApplicationId `
                     -Organization $Global:MSCloudLoginConnectionProfile.OrganizationName `
-                    -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.ExchangeOnline.CertificateThumbprint `
+                    -CertificateThumbprint $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.CertificateThumbprint `
                     -ShowBanner:$false `
                     -ShowProgress:$false `
-                    -ConnectionUri $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Endpoints.ConnectionUri `
-                    -AzureADAuthorizationEndpointUri $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Endpoints.AzureADAuthorizationEndpointUri `
+                    -ConnectionUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.ConnectionUri `
+                    -AzureADAuthorizationEndpointUri $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Endpoints.AzureADAuthorizationEndpointUri `
                     -Verbose:$false `
                     -SkipLoadingCmdletHelp | Out-Null
                 $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.ConnectedDateTime = [System.DateTime]::Now.ToString()


### PR DESCRIPTION
Three changes to the code for connecting using service principal and thumbprint:
1. $Global:MSCloudLoginConnectionProfile.OrganizationName was null and needs to have a value in order to connect
2. Connection parameters should be pulling from $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter, not $Global:MSCloudLoginConnectionProfile.ExchangeOnline
3. ShowProgress is not a valid parameter for Connect-IPPSSession

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/178)
<!-- Reviewable:end -->
