### PR TITLE
Add EXO command import handling

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.psm1
@@ -356,6 +356,15 @@ class ExchangeOnline:Workload
     [boolean]
     $SkipModuleReload = $false
 
+    [System.String[]]
+    $CmdletsToLoad = @()
+
+    [System.String[]]
+    $LoadedCmdlets = @()
+
+    [boolean]
+    $LoadedAllCmdlets = $false
+
     ExchangeOnline()
     {
     }
@@ -396,6 +405,9 @@ class ExchangeOnline:Workload
         Write-Verbose -Message 'Disconnecting from Exchange Online Connection'
         Disconnect-ExchangeOnline -Confirm:$false
         $this.Connected = $false
+        $this.LoadedAllCmdlets = $false
+        $this.LoadedCmdlets = @()
+        $this.CmdletsToLoad = @()
     }
 }
 

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -61,7 +61,15 @@ function Connect-M365Tenant
 
         [Parameter()]
         [System.Collections.Hashtable]
-        $Endpoints
+        $Endpoints,
+
+        [Parameter()]
+        [ValidateScript(
+            { $Workload -eq 'ExchangeOnline' },
+            ErrorMessage = 'This parameter is only valid for ExchangeOnline workloads.'
+        )]
+        [System.String[]]
+        $ExchangeOnlineCmdlets = @()
     )
 
     $VerbosePreference = 'SilentlyContinue'
@@ -139,6 +147,7 @@ function Connect-M365Tenant
             $Global:MSCloudLoginConnectionProfile.ExchangeOnline.AccessTokens = $AccessTokens
             $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Identity = $Identity
             $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Endpoints = $Endpoints
+            $Global:MSCloudLoginConnectionProfile.ExchangeOnline.CmdletsToLoad = $ExchangeOnlineCmdlets
             $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Connect()
         }
         'Fabric'
@@ -338,6 +347,7 @@ function Compare-InputParametersForChange
     }
     $currentParameters.Remove('Credential') | Out-Null
     $currentParameters.Remove('SkipModuleReload') | Out-Null
+    $currentParameters.Remove('CmdletsToLoad') | Out-Null
     $currentParameters.Remove('UseModernAuth') | Out-Null
     $currentParameters.Remove('ProfileName') | Out-Null
     $currentParameters.Remove('Verbose') | Out-Null


### PR DESCRIPTION
@NikCharlebois

This PR is an attempt at making the EXO command import smarter so that a user of the module can specify, which cmdlets of the EXO module to import. This results in a massively reduced memory consumption if only specific cmdlets are loaded. 
The suggestion of this PR comes from https://github.com/microsoft/Microsoft365DSC/issues/3956. 

Three new values are added to the `ExchangeOnline` workload: 
* `CmdletsToLoad` - The cmdlets of the EXO module to load
* `LoadedCmdlets` - An internal variable that holds the currently loaded cmdlets
* `LoadedAllCmdlets` - An internal variable that tells if all cmdlets of the EXO module were loaded

The approach is designed to increasingly load the new cmdlets (if specified), and if none are specified (by either omitting the new parameter `ExchangeOnlineCmdlets` or setting its value to `@()`), it will load all cmdlets in the entire module. 

**Please note: I was unable to test the functionality with the `PSSession` handling. This is a pure luck shot and needs testing by people who can reproduce that scenario.**

With that functionality, we can most likely improve the situation of https://github.com/microsoft/Microsoft365DSC/issues/4982. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/181)
<!-- Reviewable:end -->
