### PR TITLE
Fix authentication issues with Managed Identity and Azure Automation

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -297,7 +297,7 @@ function Connect-MSCloudLoginPnP
                     $connectionURL = $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl
                 }
 
-                if ('AzureAutomation/' -eq $env:AZUREPS_HOST_ENVIRONMENT)
+                if ($env:AZUREPS_HOST_ENVIRONMENT -like 'AzureAutomation*')
                 {
                     $url = $env:IDENTITY_ENDPOINT
                     $headers = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'


### PR DESCRIPTION
Fix authentication issues with Managed Identity and Azure Automation by appling the same fix from https://github.com/microsoft/MSCloudLoginAssistant/pull/175 that was applied to Microsoft Graph workload.

Since the 14th of October I started receiving some errors "An error has occurred Unable to connect to the remote server".
Adding some logs showed this additional error message:
>A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond 169.254.169.254:80

This is the case where AzureAutomation is not recognized and $env:IDENTITY_ENDPOINT is not used.
These are the values of the environment variables in those cases:
IDENTITY_ENDPOINT: http://localhost/metadata/identity/oauth2/token
AZUREPS_HOST_ENVIRONMENT: AzureAutomation

When IDENTITY_ENDPOINT is "http://127.0.0.1:20084/oauth2/token" it works fine, so probably that setup has the old AZUREPS_HOST_ENVIRONMENT value that worked up until now.

Credits to [ykuijs](https://github.com/ykuijs) for fixing this for Graph some months ago.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/183)
<!-- Reviewable:end -->
