### PR TITLE
Fixing issue in SC where an exception was thrown during reloading of module because of files that were still in use

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
@@ -8,7 +8,7 @@ function Connect-MSCloudLoginTeams
     $ProgressPreference = 'SilentlyContinue'
 
     Write-Verbose -Message "Trying to get the Get-CsTeamsCallingPolicy command from within MSCloudLoginAssistant"
-    $Global:currentErrorPreference = $ErrorActionPreference
+    $currentErrorPreference = $ErrorActionPreference
     $Global:ErrorActionPreference = 'SilentlyContinue'
     try
     {
@@ -209,6 +209,7 @@ function Connect-MSCloudLoginTeams
         $Global:MSCloudLoginConnectionProfile.Teams.MultiFactorAuthentication = $false
         $Global:MSCloudLoginConnectionProfile.Teams.Connected                 = $true
     }
+
     return
 }
 


### PR DESCRIPTION
Error:
```
The process cannot access the file 'Microsoft.Exchange.TransportMailflow-Help.xml' because it is being used by another process.
    + CategoryInfo          : WriteError: (Microsoft.Excha...ilflow-Help.xml:) [], CimException
    + FullyQualifiedErrorId : RemoveFileSystemItemIOError,Microsoft.PowerShell.Commands.RemoveItemCommand
    + PSComputerName        : localhost
 
The directory is not empty.
    + CategoryInfo          : WriteError: (en-us:) [], CimException
    + FullyQualifiedErrorId : RemoveFileSystemItemIOError,Microsoft.PowerShell.Commands.RemoveItemCommand
    + PSComputerName        : localhost
 
The directory is not empty.
    + CategoryInfo          : WriteError: (C:\Windows\Syst...XO_jcuznfih.par:) [], CimException
    + FullyQualifiedErrorId : RemoveFileSystemItemIOError,Microsoft.PowerShell.Commands.RemoveItemCommand
    + PSComputerName        : localhost
```

This issue is caused when the module is somehow still in use, locking certain files and then the code tries to unload the module. That unload also triggers the removal from disk, since it is a dynamic module. But that deletion then fails because files are still in use.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/184)
<!-- Reviewable:end -->
