### PR TITLE
Fix ValueCollection comparison against array

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -489,7 +489,8 @@ function Compare-InputParametersForChange
     if ($null -ne $globalParameters)
     {
         $diffKeys = Compare-Object -ReferenceObject @($currentParameters.Keys) -DifferenceObject @($globalParameters.Keys) -PassThru
-        $diffValues = Compare-Object -ReferenceObject @($currentParameters.Values) -DifferenceObject @($globalParameters.Values) -PassThru
+        $compareValues = @($currentParameters.Values) | Where-Object { $_ -ne $null }
+        $diffValues = Compare-Object -ReferenceObject $compareValues -DifferenceObject @($globalParameters.Values) -PassThru
     }
 
     if ($null -eq $diffKeys -and $null -eq $diffValues)

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -485,9 +485,7 @@ function Compare-InputParametersForChange
     if ($null -ne $globalParameters)
     {
         $diffKeys = Compare-Object -ReferenceObject @($currentParameters.Keys) -DifferenceObject @($globalParameters.Keys) -PassThru
-
-        $referenceObj = $currentParameters.Values
-        $diffValues = Compare-Object -ReferenceObject $referenceObj -DifferenceObject @($globalParameters.Values) -PassThru
+        $diffValues = Compare-Object -ReferenceObject @($currentParameters.Values) -DifferenceObject @($globalParameters.Values) -PassThru
     }
 
     if ($null -eq $diffKeys -and $null -eq $diffValues)

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -415,6 +415,10 @@ function Compare-InputParametersForChange
     {
         $globalParameters.Add('Url', $workloadProfile.ConnectionUrl)
     }
+    if ($null -ne $workloadProfile.ExchangeOnlineCmdlets)
+    {
+        $globalParameters.Add('ExchangeOnlineCmdlets', $ExchangeOnlineCmdlets)
+    }
 
     # This is the global graph application id. If it is something different, it means that we should compare the parameters
     if (-not [System.String]::IsNullOrEmpty($workloadProfile.ApplicationId) `


### PR DESCRIPTION
This PR fixes an issue introduced in version 1.1.16 https://github.com/microsoft/MSCloudLoginAssistant/commit/1e29cf214a471c2c61dd67a146cc3fed24bf2b99. The comparison between `referenceObj`, which is in fact a `ValueCollection`, and an array of values does not use the same comparison technique. 

While `Compare-Object` successfully compares two arrays of values with each other, comparing a `ValueCollection` against an array will always lead to a difference, no matter the contents of the objects. This leads to an false positive of `Compare-InputParametersForChange`, which in terms means that those workloads without a dedicated check outside of `Connected` being true / false will always reconnect on every call to `Connect-M365Tenant`. Best example is the MicrosoftGraph workload: Without the fix, it will always connect and keep connecting, even though the connection was successfully established on the first go. But because `Compare-InputParametersForChange` always reports true, meaning a change was detected, although there was none. 

Note: Since there is the `AccessTokens` array, and `Compare-Object` takes the order of an array into consideration, a reordered `AccessTokens` array will lead to a false positive. That's something we have to keep in mind, but since there shouldn't be any change after a connection was established (unless one does so specifically), it will work without issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/185)
<!-- Reviewable:end -->
