### PR TITLE
Enable more workload disconnects

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
@@ -301,6 +301,11 @@ class Azure:Workload
 
         Connect-MSCloudLoginAzure
     }
+
+    [void] Disconnect()
+    {
+        Disconnect-MSCloudLoginAzure
+    }
 }
 
 class AzureDevOPS:Workload
@@ -586,6 +591,11 @@ class MicrosoftGraph:Workload
 
         Connect-MSCloudLoginMicrosoftGraph
     }
+
+    [void] Disconnect()
+    {
+        Disconnect-MSCloudLoginMicrosoftGraph
+    }
 }
 
 class PnP:Workload
@@ -648,6 +658,11 @@ class PnP:Workload
 
 
         Connect-MSCloudLoginPnP -ForceRefreshConnection $ForceRefresh
+    }
+
+    [void] Disconnect()
+    {
+        Disconnect-MSCloudLoginPnP
     }
 }
 
@@ -882,5 +897,10 @@ class Teams:Workload
     {
         ([Workload]$this).Setup()
         Connect-MSCloudLoginTeams
+    }
+
+    [void] Disconnect()
+    {
+        Disconnect-MSCloudLoginTeams
     }
 }

--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
@@ -110,3 +110,23 @@ function Connect-MSCloudLoginAzure
         throw 'Specified authentication method is not supported.'
     }
 }
+
+function Disconnect-MSCloudLoginAzure
+{
+    [CmdletBinding()]
+    param()
+
+    $source = 'Disconnect-MSCloudLoginAzure'
+
+    if ($Script:MSCloudLoginConnectionProfile.Azure.Connected)
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'Attempting to disconnect from Azure' -Source $source
+        Disconnect-AzAccount | Out-Null
+        $Script:MSCloudLoginConnectionProfile.Azure.Connected = $false
+        Add-MSCloudLoginAssistantEvent -Message 'Successfully disconnected from Azure' -Source $source
+    }
+    else
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'No connections to Azure were found' -Source $source
+    }
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.ps1
@@ -290,3 +290,23 @@ function Connect-MSCloudLoginMSGraphWithUser
         }
     }
 }
+
+function Disconnect-MSCloudLoginMicrosoftGraph
+{
+    [CmdletBinding()]
+    param()
+
+    $source = 'Disconnect-MSCloudLoginMicrosoftGraph'
+
+    if ($Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected)
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'Attempting to disconnect from Microsoft Graph' -Source $source
+        Disconnect-MgGraph | Out-Null
+        $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+        Add-MSCloudLoginAssistantEvent -Message 'Successfully disconnected from Microsoft Graph' -Source $source
+    }
+    else
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'No connections to Microsoft Graph were found' -Source $source
+    }
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -493,3 +493,23 @@ function Connect-MSCloudLoginPnP
     }
     return
 }
+
+function Disconnect-MSCloudLoginPnP
+{
+    [CmdletBinding()]
+    param()
+
+    $source = 'Disconnect-MSCloudLoginPnP'
+
+    if ($Script:MSCloudLoginConnectionProfile.PnP.Connected)
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'Attempting to disconnect from PnP' -Source $source
+        Disconnect-PnPOnline | Out-Null
+        $Script:MSCloudLoginConnectionProfile.PnP.Connected = $false
+        Add-MSCloudLoginAssistantEvent -Message 'Successfully disconnected from PnP' -Source $source
+    }
+    else
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'No connections to PnP were found' -Source $source
+    }
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
@@ -250,3 +250,23 @@ function Connect-MSCloudLoginTeamsMFA
         throw $_
     }
 }
+
+function Disconnect-MSCloudLoginTeams
+{
+    [CmdletBinding()]
+    param()
+
+    $source = 'Disconnect-MSCloudLoginTeams'
+
+    if ($Script:MSCloudLoginAssistant.Teams.Connected)
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'Attempting to disconnect from Microsoft Teams' -Source $source
+        Disconnect-MicrosoftTeams | Out-Null
+        $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+        Add-MSCloudLoginAssistantEvent -Message 'Successfully disconnected from Microsoft Teams' -Source $source
+    }
+    else
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'No connections to Microsoft Teams were found.' -Source $source
+    }
+}


### PR DESCRIPTION
This PR removes the unnecessary `Write-Verbose $PSScriptRoot -Verbose` statement from the top of the module and adds four more disconnect methods to the workloads: 

* Azure: Disconnect-MSCloudLoginAzure
* Microsoft Graph: Disconnect-MSCloudLoginMicrosoftGraph
* PnP: Disconnect-MSCloudLoginPnP
* Teams: Disconnect-MSCloudLoginTeams

The connection context is only reset if a disconnect for all workloads is done. Otherwise, an event will be logged and the connection will not be terminated for this workload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/189)
<!-- Reviewable:end -->
