### PR TITLE
Exclude Url from comparison if empty

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -112,11 +112,11 @@ function Connect-M365Tenant
     elseif ( $Script:MSCloudLoginConnectionProfile.$workloadInternalName.Connected `
             -and (Compare-InputParametersForChange -CurrentParamSet $PSBoundParameters))
     {
-        Add-MSCloudLoginAssistantEvent -Message 'Resetting connection profile' -Source $source
+        Add-MSCloudLoginAssistantEvent -Message "Resetting connection for workload $workloadInternalName" -Source $source
         $Script:MSCloudLoginConnectionProfile.$workloadInternalName.Connected = $false
     }
 
-    Add-MSCloudLoginAssistantEvent -Message "Trying to connect to platform {$Workload}" -Source $source
+    Add-MSCloudLoginAssistantEvent -Message "Checking connection to platform {$Workload}" -Source $source
     switch ($Workload)
     {
         'AdminAPI'
@@ -542,6 +542,7 @@ function Compare-InputParametersForChange
     )
 
     $currentParameters = $currentParamSet
+    $source = 'Compare-InputParametersForChange'
 
     if ($null -ne $currentParameters['Credential'].UserName)
     {
@@ -676,6 +677,10 @@ function Compare-InputParametersForChange
     {
         $currentParameters.Remove('Identity') | Out-Null
     }
+    if ([System.String]::IsNullOrEmpty($currentParameters.Url))
+    {
+        $currentParameters.Remove('Url') | Out-Null
+    }
 
     if ($null -ne $globalParameters)
     {
@@ -691,6 +696,7 @@ function Compare-InputParametersForChange
     }
 
     # We found differences, so we need to connect
+    Add-MSCloudLoginAssistantEvent -Message "Found differences in parameters: $diffKeys, with values: $diffValues" -Source $source
     return $true
 }
 


### PR DESCRIPTION
This PR removes the `Url` parameter from the comparison in `Compare-InputParametersForChange` if the provided url is null or an empty string. This prevents repeated reconnections to Microsoft Graph reported in https://github.com/microsoft/Microsoft365DSC/issues/4982#issuecomment-2551808114.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/190)
<!-- Reviewable:end -->
