### PR TITLE
Reduce web calls to Exchange Online

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
@@ -23,7 +23,7 @@ function Connect-MSCloudLoginExchangeOnline
     {
         try
         {
-            Get-AcceptedDomain -ErrorAction Stop
+            $null = Get-Command -Name Get-AcceptedDomain -ErrorAction Stop
 
             if (-not $loadAllCmdlets)
             {
@@ -49,15 +49,6 @@ function Connect-MSCloudLoginExchangeOnline
         {
             Add-MSCloudLoginAssistantEvent -Message 'Failed' -Source $source
         }
-    }
-
-    try
-    {
-        Add-MSCloudLoginAssistantEvent "Current domain: $($(Get-AcceptedDomain).Name)" -ErrorAction Continue -Source $source
-    }
-    catch
-    {
-        Add-MSCloudLoginAssistantEvent -Message 'Failed to load Get-AcceptedDomain' -Source $source -EntryType 'Error'
     }
 
     if ($Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected -and `


### PR DESCRIPTION
Follow up from https://github.com/microsoft/Microsoft365DSC/issues/5615.

This PR removes two calls to `Get-AcceptedDomain` to reduce the network load and improve overall speed.

The first call to `Get-AcceptedDomain` makes sure that the EXO module is loaded and has a connection. The availability of the module can also be checked if `Get-Command` returns an output and does not throw with the message that the command is not available. Connection issues in other workloads (e.g. an expired token) are normally not handled. 

The second call is just a duplicate in the first load that does not have any impact. As soon as `Connect-ExchangeOnline` is called, the session will be enabled and all connections alive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/192)
<!-- Reviewable:end -->
