### PR TITLE
Fix invalid parameter sets, disconnect test and typo

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
@@ -604,7 +604,7 @@ class PnP:Workload
     $ConnectionUrl
 
     [string]
-    $ClientId = '9bc3ab49-b65d-410a-85ad-de819febfddc'
+    $ClientId = '9bc3ab49-b65d-410a-85ad-de819febfddc' # Microsoft Sharepoint Online Management Shell
 
     [string]
     $RedirectURI = 'https://oauth.spops.microsoft.com/'

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -411,7 +411,7 @@ function Reset-MSCloudLoginConnectionProfileContext
     Add-MSCloudLoginAssistantEvent -Message 'Resetting connection profile' -Source $source
     foreach ($workloadToReset in $Workload)
     {
-        $disconnectExists = $null -ne ($Script:MSCloudLoginConnectionProfile.$workloadToReset | Get-Member -Name 'Disconnect' -MemberType Method)
+        $disconnectExists = $null -ne ($Script:MSCloudLoginConnectionProfile.$workloadToReset | Get-Member -Name 'Disconnect' -MemberType Method -ErrorAction SilentlyContinue)
         if ($disconnectExists)
         {
             $Script:MSCloudLoginConnectionProfile.$workloadToReset.Disconnect()

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -271,8 +271,7 @@ function Connect-MSCloudLoginPnP
                     Connect-PnPOnline -Url $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl `
                         -Credentials $Script:MSCloudLoginConnectionProfile.PnP.Credentials `
                         -ClientId $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId `
-                        -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment `
-                        -SPOManagementShell
+                        -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment
                 }
                 else
                 {
@@ -293,23 +292,23 @@ function Connect-MSCloudLoginPnP
             {
                 if ($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl -or $ForceRefreshConnection)
                 {
-                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials' -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials using SPOManagementShell' -Source $source
                     Add-MSCloudLoginAssistantEvent -Message "URL: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
                     Add-MSCloudLoginAssistantEvent -Message "ConnectionUrl: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
                     Connect-PnPOnline -Url $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl `
                         -Credentials $Script:MSCloudLoginConnectionProfile.PnP.Credentials `
                         -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment `
-                        -SPOManagementShell
+                        -ClientId $Script:MSCloudLoginConnectionProfile.PnP.ClientId
                 }
                 else
                 {
-                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials' -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials using SPOManagementShell' -Source $source
                     Add-MSCloudLoginAssistantEvent -Message "URL: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
                     Add-MSCloudLoginAssistantEvent -Message "AdminUrl: $($Script:MSCloudLoginConnectionProfile.PnP.AdminUrl)" -Source $source
                     Connect-PnPOnline -Url $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl `
                         -Credentials $Script:MSCloudLoginConnectionProfile.PnP.Credentials `
                         -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment `
-                        -SPOManagementShell
+                        -ClientId $Script:MSCloudLoginConnectionProfile.PnP.ClientId
                 }
 
                 $Script:MSCloudLoginConnectionProfile.PnP.ConnectedDateTime = [System.DateTime]::Now.ToString()

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.ps1
@@ -188,7 +188,7 @@ function Connect-MSCloudLoginSecurityCompliance
             Connect-MSCloudLoginSecurityComplianceMFA -TenantId $Script:MSCloudLoginConnectionProfile.SecurityComplianceCenter.TenantId
         }
     }
-    elseif ($Script:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthenticationType -eq 'AccessToken')
+    elseif ($Script:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthenticationType -eq 'AccessTokens')
     {
         Add-MSCloudLoginAssistantEvent -Message 'Connecting to Security & Compliance with Access Token' -Source $source
         Connect-M365Tenant -Workload 'ExchangeOnline' `


### PR DESCRIPTION
This PR contains the following two fixes: 

* Fixes an issue with the `Disconnect` method test where previously an error would be thrown if the method didn't exist
* Fixes an issue with resolving parameter sets in the PnP workload and credentials (and with application id) sign-in
* Fixes a typo in the SecurityCompliance workload where `AccessToken` was written without a trailing `s`

Fixes the following issue: 
- Fixes #191 
- Fixes #180

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/195)
<!-- Reviewable:end -->
