### PR TITLE
Add CredentialsWithApplicationId to PnP workload

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -784,7 +784,8 @@ function Get-SPOAdminUrl
             }
             else
             {
-                if ($_.Exception.Message -eq 'Insufficient privileges to complete the operation.')
+                if ($_.Exception.Message -eq 'Insufficient privileges to complete the operation.' -or `
+                    $_.Exception.Message -like "*Forbidden*")
                 {
                     throw "The Graph application does not have the correct permissions to access Domains. Make sure you run 'Connect-MgGraph -Scopes Sites.Read.All' first!"
                 }

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -76,7 +76,7 @@ function Connect-MSCloudLoginPnP
                 }
                 else
                 {
-                    throw 'Unable to retrieve SharePoint Admin Url. Check if the Graph can be contacted successfully.'
+                    throw 'Unable to retrieve SharePoint Admin Url. Check if Microsoft Graph can be contacted successfully.'
                 }
             }
             else
@@ -261,7 +261,36 @@ function Connect-MSCloudLoginPnP
             {
                 throw 'You cannot specify TenantId with Credentials when connecting to PnP.'
             }
-            elseif ($Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType -eq 'CredentialsWithApplicationId')
+            elseif ($Script:MSCloudLoginConnectionProfile.Pnp.AuthenticationType -eq 'CredentialsWithApplicationId')
+            {
+                if ($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl -or $ForceRefreshConnection)
+                {
+                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials and Application Id' -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "URL: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "ConnectionUrl: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "ApplicationId: $($Script:MSCloudLoginConnectionProfile.PnP.ApplicationId)" -Source $source
+                    Connect-PnPOnline -Url $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl `
+                        -ClientId $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId `
+                        -Credentials $Script:MSCloudLoginConnectionProfile.PnP.Credentials `
+                        -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment
+                }
+                else
+                {
+                    Add-MSCloudLoginAssistantEvent -Message 'Connecting with Credentials and Application Id' -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "URL: $($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl)" -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "AdminUrl: $($Script:MSCloudLoginConnectionProfile.PnP.AdminUrl)" -Source $source
+                    Add-MSCloudLoginAssistantEvent -Message "ApplicationId: $($Script:MSCloudLoginConnectionProfile.PnP.ApplicationId)" -Source $source
+                    Connect-PnPOnline -Url $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl `
+                        -ClientId $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId `
+                        -Credentials $Script:MSCloudLoginConnectionProfile.PnP.Credentials `
+                        -AzureEnvironment $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment
+                }
+
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectedDateTime = [System.DateTime]::Now.ToString()
+                $Script:MSCloudLoginConnectionProfile.PnP.MultiFactorAuthentication = $false
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected = $true
+            }
+            elseif ($Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType -eq 'Credentials')
             {
                 if ($Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl -or $ForceRefreshConnection)
                 {

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -29,9 +29,12 @@ function Connect-MSCloudLoginPnP
         try
         {
             Get-PnPAlert -ErrorAction 'Stop' | Out-Null
-            Add-MSCloudLoginAssistantEvent -Message 'Retrieved results from the command. Not re-connecting to PnP.' -Source $source
-            $Script:MSCloudLoginConnectionProfile.PnP.Connected = $true
-            return
+            if (-not $ForceRefreshConnection)
+            {
+                Add-MSCloudLoginAssistantEvent -Message 'Retrieved results from the command. Not re-connecting to PnP.' -Source $source
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected = $true
+                return
+            }
         }
         catch
         {


### PR DESCRIPTION
Add `CredentialsWithApplicationId` to supported authentication methods for the PnP workload. 

- Fixes https://github.com/microsoft/Microsoft365DSC/issues/4567

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/198)
<!-- Reviewable:end -->
