### PR TITLE
Added specific check for Machine Environment variable

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -1,4 +1,5 @@
-$Script:WriteToEventLog = $env:MSCLOUDLOGINASSISTANT_WRITETOEVENTLOG -eq 'true'
+$Script:WriteToEventLog = ([Environment]::GetEnvironmentVariable('MSCLOUDLOGINASSISTANT_WRITETOEVENTLOG', 'Machine') -eq 'true') -or `
+                          ($env:MSCLOUDLOGINASSISTANT_WRITETOEVENTLOG -eq 'true')
 
 . "$PSScriptRoot\ConnectionProfile.ps1"
 . "$PSScriptRoot\CustomEnvironment.ps1"


### PR DESCRIPTION
Added a specific check for Machine Environment variable, which does not work as expected in DevOps agents.

By specifically checking this variable, logging is now activated when the machine environment variable is set or when the current process environment variable is set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/205)
<!-- Reviewable:end -->
