### PR TITLE
Add Cloud Environment variable to Connect-AzAccount to allow connections to non-Commercial clouds

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
@@ -58,7 +58,7 @@ function Connect-MSCloudLoginAzure
             try
             {
                 Add-MSCloudLoginAssistantEvent -Message 'Attempting to connect to Azure using Credentials (MFA)' -Source $source
-                Connect-AzAccount
+                Connect-AzAccount -Environment $Script:MSCloudLoginConnectionProfile.Azure.EnvironmentName
                 $Script:MSCloudLoginConnectionProfile.Azure.ConnectedDateTime = [System.DateTime]::Now.ToString()
                 $Script:MSCloudLoginConnectionProfile.Azure.Connected = $true
                 $Script:MSCloudLoginConnectionProfile.Azure.MultiFactorAuthentication = $true


### PR DESCRIPTION
Add Cloud Environment variable to Connect-AzAccount to allow connections to non-Commercial clouds for the interactive MFA connection path.

Fixes [#211]