### PR TITLE
Add logic for Azure connection re-use on Connect-MSCloudLoginAzure

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
@@ -6,6 +6,27 @@ function Connect-MSCloudLoginAzure
     $InformationPreference = 'SilentlyContinue'
     $ProgressPreference = 'SilentlyContinue'
     $source = 'Connect-MSCloudLoginAzure'
+    # If the current profile is not the same we expect, make the switch.
+    if ($Script:MSCloudLoginConnectionProfile.Azure.Connected)
+        {
+        write-host "azure connected"
+        if (($Script:MSCloudLoginConnectionProfile.Azure.AuthenticationType -eq 'ServicePrincipalWithSecret' `
+                    -or $Script:MSCloudLoginConnectionProfile.Azure.AuthenticationType -eq 'Identity') `
+                -and (Get-Date -Date $Script:MSCloudLoginConnectionProfile.Azure.ConnectedDateTime) -lt [System.DateTime]::Now.AddMinutes(-50))
+            {
+                Add-MSCloudLoginAssistantEvent -Message 'Token is about to expire, renewing' -Source $source
+
+                $Script:MSCloudLoginConnectionProfile.Azure.Connected = $false
+            }
+            elseif ($null -eq (Get-azContext))
+            {
+                $Script:MSCloudLoginConnectionProfile.Azure.Connected = $false
+            }
+            else
+            {
+                return
+            }
+    }
 
     if ($Script:MSCloudLoginConnectionProfile.Azure.AuthenticationType -eq 'ServicePrincipalWithThumbprint')
     {


### PR DESCRIPTION
Add existing connection check logic to start of Connect-MSCloudLoginAzure to allow connection re-use

Fixes [#210]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/214)
<!-- Reviewable:end -->
