### PR TITLE
Remove hard-coded set of Azure connection false which forces re-connection on each call

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -142,7 +142,6 @@ function Connect-M365Tenant
             $Script:MSCloudLoginConnectionProfile.Azure.CertificateThumbprint = $CertificateThumbprint
             $Script:MSCloudLoginConnectionProfile.Azure.AccessTokens = $AccessTokens
             $Script:MSCloudLoginConnectionProfile.Azure.Endpoints = $Endpoints
-            $Script:MSCloudLoginConnectionProfile.Azure.Connected = $false
             $Script:MSCloudLoginConnectionProfile.Azure.Connect()
         }
         'AzureDevOPS'


### PR DESCRIPTION
``` Connect-M365Tenant ``` Azure connection setup always forced the connection to false which breaks downstream connection re-use logic.

Fixes [#208]