### PR TITLE
Add support for Azure Management URL to prevent use of hard-coded endpoints

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
@@ -314,6 +314,9 @@ class AdminAPI:Workload
 
 class Azure:Workload
 {
+    [string]
+    $ManagementUrl
+
     Azure()
     {
     }

--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
@@ -109,6 +109,14 @@ function Connect-MSCloudLoginAzure
     {
         throw 'Specified authentication method is not supported.'
     }
+
+    #if the connection to azure was successful update the management URL
+    if ($Script:MSCloudLoginConnectionProfile.Azure.Connected)
+    {
+        $managementUrl = (Get-AzContext).Environment.ResourceManagerUrl
+        Add-MSCloudLoginAssistantEvent -Message "Setting Azure management URL to $managementUrl" -Source $source
+        $Script:MSCloudLoginConnectionprofile.Azure.ManagementUrl = $managementUrl
+    }
 }
 
 function Disconnect-MSCloudLoginAzure


### PR DESCRIPTION
Currently there is no easy way for consumers of the Azure resource to get the endpoint management url.  This results in use of hard-coded endpoints breaking cross cloud, or extra calls to get-azcontext to get the value for each consumer.  

This change adds support for the ManagementUrl to be attached to the Azure workload object and populated at connection time.
 Fixes [#209]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/217)
<!-- Reviewable:end -->
