### PR TITLE
Fix Azure AccessToken login

### DIFF
--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.ps1
@@ -96,7 +96,8 @@ function Connect-MSCloudLoginAzure
         Add-MSCloudLoginAssistantEvent -Message 'Attempting to connect to Azure using Access Token' -Source $source
         Connect-AzAccount -Tenant $Script:MSCloudLoginConnectionProfile.Azure.TenantId `
             -Environment $Script:MSCloudLoginConnectionProfile.Azure.EnvironmentName `
-            -AccessToken $Script:MSCloudLoginConnectionProfile.Azure.AccessTokens | Out-Null
+            -AccessToken $Script:MSCloudLoginConnectionProfile.Azure.AccessTokens[0] `
+            -AccountId "MSCloudLoginAssistant" | Out-Null
         $Script:MSCloudLoginConnectionProfile.Azure.ConnectedDateTime = [System.DateTime]::Now.ToString()
         $Script:MSCloudLoginConnectionProfile.Azure.Connected = $true
         $Script:MSCloudLoginConnectionProfile.Azure.MultiFactorAuthentication = $false


### PR DESCRIPTION
This PR fixes an issue with the login using access tokens in the Azure workload. `AccessTokens` is an array and only the first element contains the real access token, therefore we index into the first element. Additionally, using `-AccessToken` with `Connect-AzAccount` requires that the `-AccountId` parameter is specified as well. The description is the following: 

> Id for Account, associated with your access token. In User authentication flows, the AccountId is user name / user id; In AccessToken flow, it is the AccountId for the access token; In ManagedService flow, it is the associated client Id of UserAssigned identity. To use the SystemAssigned identity, leave this field blank.

After testing, it doesn't matter if the "correct" identity of the access token is used. Any value in the field works. To make identification possible, we'll use `MSCloudLoginAssistant` as a hardcoded value instead of prompting the user for a user principal name using an additional parameter.

- Fixes https://github.com/microsoft/Microsoft365DSC/issues/6273

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/MSCloudLoginAssistant/219)
<!-- Reviewable:end -->
