### PR TITLE
Fix retrieval of access token

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -1081,6 +1081,10 @@ function Get-MSCloudLoginAccessToken
 
         [Parameter(Mandatory = $True)]
         [System.String]
+        $AuthorizationUrl,
+
+        [Parameter(Mandatory = $True)]
+        [System.String]
         $AzureADAuthorizationEndpointUri,
 
         [Parameter(Mandatory = $True)]
@@ -1101,7 +1105,8 @@ function Get-MSCloudLoginAccessToken
     try
     {
         Add-MSCloudLoginAssistantEvent -Message 'Connecting by endpoints URI' -Source $source
-        $response = Get-AuthToken -TokenEndpoint $AzureADAuthorizationEndpointUri `
+        $response = Get-AuthToken -AuthorizationUrl $AuthorizationUrl `
+            -TokenEndpoint $AzureADAuthorizationEndpointUri `
             -Scope $ConnectionUri `
             -ClientId $ApplicationId `
             -TenantId $TenantId `

--- a/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MicrosoftGraph.ps1
@@ -56,6 +56,7 @@ function Connect-MSCloudLoginMicrosoftGraph
                     $null -ne $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TokenUrl)
                 {
                     $accessToken = Get-MSCloudLoginAccessToken -ConnectionUri $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Scope `
+                        -AuthorizationUrl $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthorizationUrl `
                         -AzureADAuthorizationEndpointUri $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TokenUrl `
                         -ApplicationId $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId `
                         -TenantId $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId `

--- a/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/PnP.ps1
@@ -105,6 +105,7 @@ function Connect-MSCloudLoginPnP
                         $null -ne $Script:MSCloudLoginConnectionProfile.PnP.TokenUrl)
                     {
                         $accessToken = Get-MSCloudLoginAccessToken -ConnectionUri $Script:MSCloudLoginConnectionProfile.PnP.Scope `
+                            -AuthorizationUrl $Script:MSCloudLoginConnectionProfile.PnP.AuthorizationUrl `
                             -AzureADAuthorizationEndpointUri $Script:MSCloudLoginConnectionProfile.PnP.TokenUrl `
                             -ApplicationId $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId `
                             -TenantId $Script:MSCloudLoginConnectionProfile.PnP.TenantId `

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
@@ -40,6 +40,7 @@ function Connect-MSCloudLoginTeams
             $null -eq $Script:CustomEnvConfig.CustomTeamsEndpoints)
         {
             $graphAccessToken = Get-MSCloudLoginAccessToken -ConnectionUri $Script:MSCloudLoginConnectionProfile.Teams.GraphScope `
+                -AuthorizationUrl $Script:MSCloudLoginConnectionProfile.Teams.AuthorizationUrl `
                 -AzureADAuthorizationEndpointUri $Script:MSCloudLoginConnectionProfile.Teams.TokenUrl `
                 -ApplicationId $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId `
                 -TenantId $Script:MSCloudLoginConnectionProfile.Teams.TenantId `
@@ -47,6 +48,7 @@ function Connect-MSCloudLoginTeams
             $Script:MSCloudLoginConnectionProfile.Teams.AccessTokens += $graphAccessToken
 
             $teamsAccessToken = Get-MSCloudLoginAccessToken -ConnectionUri $Script:MSCloudLoginConnectionProfile.Teams.TeamsScope `
+                -AuthorizationUrl $Script:MSCloudLoginConnectionProfile.Teams.AuthorizationUrl `
                 -AzureADAuthorizationEndpointUri $Script:MSCloudLoginConnectionProfile.Teams.TokenUrl `
                 -ApplicationId $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId `
                 -TenantId $Script:MSCloudLoginConnectionProfile.Teams.TenantId `


### PR DESCRIPTION
Function `Get-MSCloudLoginAccessToken` calls internally `Get-AuthToken` which requires parameter `AuthorizationUrl` as mandatory but `Get-MSCloudLoginAccessToken` misses this, this PR adds that missing parameter and adjusts the calls to that function