### PR TITLE
Fixes

### DIFF
--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
@@ -526,13 +526,7 @@ class ExchangeOnline:Workload
 
     [void] Disconnect()
     {
-        $source = 'ExchangeOnline-Disconnect()'
-        Add-MSCloudLoginAssistantEvent -Message 'Disconnecting from Exchange Online Connection' -Source $source
-        Disconnect-ExchangeOnline -Confirm:$false
-        $this.Connected = $false
-        $this.LoadedAllCmdlets = $false
-        $this.LoadedCmdlets = @()
-        $this.CmdletsToLoad = @()
+        Disconnect-MSCloudLoginExchangeOnline
     }
 }
 

--- a/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
+++ b/Modules/MSCloudLoginAssistant/ConnectionProfile.ps1
@@ -775,7 +775,7 @@ class PnP:Workload
     $AdminUrl
 
     [string]
-    [ValidateSet('Production', 'PPE', 'China', 'Germany', 'USGovernment', 'USGovernmentHigh', 'USGovernmentDoD', 'France', 'Custom')]
+    [ValidateSet('Production', 'PPE', 'China', 'Germany', 'USGovernment', 'USGovernmentHigh', 'USGovernmentDoD', 'France', 'Custom', 'BleuCloud', 'DelosCloud')]
     $PnPAzureEnvironment
 
     PnP()

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
@@ -416,8 +416,19 @@ function Disconnect-MSCloudLoginExchangeOnline
     param()
 
     $source = 'Disconnect-MSCloudLoginExchangeOnline'
-    Add-MSCloudLoginAssistantEvent -Message 'Disconnecting from Exchange Online' -Source $source
 
-    Disconnect-ExchangeOnline -Confirm:$false
-    $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+    if ($Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected)
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'Attempting to disconnect from Exchange Online' -Source $source
+        Disconnect-ExchangeOnline -Confirm:$false
+        $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+        $Script:MSCloudLoginConnectionProfile.ExchangeOnline.LoadedAllCmdlets = $false
+        $Script:MSCloudLoginConnectionProfile.ExchangeOnline.LoadedCmdlets = @()
+        $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CmdletsToLoad = @()
+        Add-MSCloudLoginAssistantEvent -Message 'Successfully disconnected from Exchange Online' -Source $source
+    }
+    else
+    {
+        Add-MSCloudLoginAssistantEvent -Message 'No connections to Exchange Online were found' -Source $source
+    }
 }

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Returns the Windows principal of the current user.
+
+.DESCRIPTION
+    Thin wrapper around the Windows identity APIs used to decide whether the
+    current session is elevated. Extracted so that unit tests can substitute
+    the principal without depending on the privileges of the test runner.
+#>
+function Get-MSCloudLoginWindowsPrincipal
+{
+    [CmdletBinding()]
+    [OutputType([System.Security.Principal.WindowsPrincipal])]
+    param()
+
+    return [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+}
+
 function Connect-MSCloudLoginExchangeOnline
 {
     [CmdletBinding()]
@@ -189,7 +207,8 @@ function Connect-MSCloudLoginExchangeOnline
                 $Script:MSCloudLoginConnectionProfile.OrganizationName = $Script:MSCloudLoginConnectionProfile.ExchangeOnline.TenantId
             }
 
-            if (($IsWindows -or $PSVersionTable.PSVersion.Major -eq 5) -and -not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+            if (($IsWindows -or $PSVersionTable.PSVersion.Major -eq 5) -and `
+                -not (Get-MSCloudLoginWindowsPrincipal).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
             {
                 throw 'Certificate Path authentication on Windows requires the command to be run as Administrator.'
             }

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
@@ -53,29 +53,13 @@ function Connect-MSCloudLoginTeams
     $ProgressPreference = 'SilentlyContinue'
     $source = 'Connect-MSCloudLoginTeams'
 
-    Add-MSCloudLoginAssistantEvent -Message 'Trying to get the Get-CsTeamsCallingPolicy command from within MSCloudLoginAssistant' -Source $source
-    try
+    if (Test-MSCloudLoginConnectionReusable -WorkloadProfile $Script:MSCloudLoginConnectionProfile.Teams `
+            -ProbeScript { Get-CsTeamsCallingPolicy } `
+            -Source $source)
     {
-        $results = Get-CsTeamsCallingPolicy -ErrorAction Stop
-        if ($null -ne $results)
-        {
-            Add-MSCloudLoginAssistantEvent -Message 'Succeeded' -Source $source
-            $Script:MSCloudLoginConnectionProfile.Teams.CompleteConnection($Script:MSCloudLoginConnectionProfile.Teams.MultiFactorAuthentication)
-            return
-        }
-    }
-    catch
-    {
-        # Liveness probe: a failure only means that there is no usable Teams session yet.
-        Add-MSCloudLoginAssistantEvent -Message "Probe for existing Microsoft Teams session failed: $($_.Exception.Message)" -Source $source
-        $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
-    }
-
-    if ($Script:MSCloudLoginConnectionProfile.Teams.Connected)
-    {
-        Add-MSCloudLoginAssistantEvent -Message 'Already connected to Microsoft Teams. Not attempting to re-connect.' -Source $source
         return
     }
+
     Add-MSCloudLoginAssistantEvent -Message 'No Active Connections to Microsoft Teams were found.' -Source $source
 
     if ($Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType -eq 'ServicePrincipalWithThumbprint')

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.ps1
@@ -1,3 +1,50 @@
+function Get-MSCloudLoginTeamsEnvironmentParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param(
+        [Parameter()]
+        [System.String]
+        $EnvironmentName
+    )
+
+    $teamsEnvironmentNames = @{
+        AzureUSGovernment = 'TeamsGCCH'
+        USGovernmentDoD   = 'TeamsDOD'
+        AzureDOD          = 'TeamsDOD'
+        AzureChinaCloud   = 'TeamsChina'
+    }
+
+    if ($teamsEnvironmentNames.ContainsKey($EnvironmentName))
+    {
+        return @{ TeamsEnvironmentName = $teamsEnvironmentNames[$EnvironmentName] }
+    }
+
+    return @{}
+}
+
+function Connect-MSCloudLoginTeamsCustomEnvironment
+{
+    [CmdletBinding()]
+    param()
+
+    if ($null -eq $Script:CustomEnvConfig.CustomTeamsEndpoints -or -not $Script:CustomEnvConfig.CustomEnvironment)
+    {
+        return $false
+    }
+
+    if ($PSVersionTable.PSVersion.Major -gt 5)
+    {
+        throw 'Custom Environment connections to Microsoft Teams are only supported in PowerShell 5. Please run this module in PowerShell 5 to connect to Microsoft Teams in a custom environment.'
+    }
+
+    Set-TeamsEnvironmentConfig -EndpointUris $Script:CustomEnvConfig.CustomTeamsEndpoints
+    Connect-MicrosoftTeams -ApplicationId $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId `
+        -TenantId $Script:MSCloudLoginConnectionProfile.Teams.TenantId `
+        -CertificateThumbprint $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint
+    return $true
+}
+
 function Connect-MSCloudLoginTeams
 {
     [CmdletBinding()]
@@ -58,18 +105,7 @@ function Connect-MSCloudLoginTeams
             Connect-MicrosoftTeams -AccessTokens @($graphAccessToken, $teamsAccessToken)
             Add-MSCloudLoginAssistantEvent -Message 'Successfully connected to the Microsoft Graph API using Certificate Thumbprint' -Source $source
         }
-        elseif ($null -ne $Script:CustomEnvConfig.CustomTeamsEndpoints -and $Script:CustomEnvConfig.CustomEnvironment)
-        {
-            if ($PSVersionTable.PSVersion.Major -gt 5)
-            {
-                throw 'Custom Environment connections to Microsoft Teams are only supported in PowerShell 5. Please run this module in PowerShell 5 to connect to Microsoft Teams in a custom environment.'
-            }
-            Set-TeamsEnvironmentConfig -EndpointUris $Script:CustomEnvConfig.CustomTeamsEndpoints
-            Connect-MicrosoftTeams -ApplicationId $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId `
-                -TenantId $Script:MSCloudLoginConnectionProfile.Teams.TenantId `
-                -CertificateThumbprint $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint
-        }
-        else
+        elseif (-not (Connect-MSCloudLoginTeamsCustomEnvironment))
         {
             try
             {
@@ -79,19 +115,8 @@ function Connect-MSCloudLoginTeams
                     CertificateThumbprint = $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint
                 }
 
-                if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureUSGovernment')
-                {
-                    $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsGCCH')
-                }
-                elseif ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'USGovernmentDoD' -or `
-                        $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureDOD')
-                {
-                    $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsDOD')
-                }
-                elseif ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureChinaCloud')
-                {
-                    $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsChina')
-                }
+                $ConnectionParams += Get-MSCloudLoginTeamsEnvironmentParameters `
+                    -EnvironmentName $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName
 
                 Connect-MicrosoftTeams @ConnectionParams | Out-Null
             }
@@ -125,26 +150,9 @@ function Connect-MSCloudLoginTeams
                 Credential = $Script:MSCloudLoginConnectionProfile.Teams.Credentials
             }
 
-            if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureUSGovernment')
-            {
-                $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsGCCH')
-            }
-
-            if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'USGovernmentDoD' -or `
-                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureDOD')
-            {
-                $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsDOD')
-            }
-
-            if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureChinaCloud')
-            {
-                $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsChina')
-            }
-
-            if (-not [System.String]::IsNullOrEmpty($Script:MSCloudLoginConnectionProfile.Teams.TenantId))
-            {
-                $ConnectionParams.Add('TenantId', $Script:MSCloudLoginConnectionProfile.Teams.TenantId)
-            }
+            $ConnectionParams += Get-MSCloudLoginTeamsEnvironmentParameters `
+                -EnvironmentName $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName
+            $ConnectionParams['TenantId'] = $Script:MSCloudLoginConnectionProfile.Teams.TenantId
 
             Add-MSCloudLoginAssistantEvent -Message 'Connecting to Microsoft Teams using credentials.' -Source $source
             Add-MSCloudLoginAssistantEvent -Message "Params: $($ConnectionParams | Out-String)" -Source $source
@@ -212,20 +220,9 @@ function Connect-MSCloudLoginTeamsMFA
 
     try
     {
-        $ConnectionParams = @{}
-        if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureUSGovernment')
-        {
-            $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsGCCH')
-        }
-        if ($Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'USGovernmentDoD' -or `
-                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName -eq 'AzureDOD')
-        {
-            $ConnectionParams.Add('TeamsEnvironmentName', 'TeamsDOD')
-        }
-        if (-not [System.String]::IsNullOrEmpty($Script:MSCloudLoginConnectionProfile.Teams.TenantId))
-        {
-            $ConnectionParams.Add('TenantId', $Script:MSCloudLoginConnectionProfile.Teams.TenantId)
-        }
+        $ConnectionParams = Get-MSCloudLoginTeamsEnvironmentParameters `
+            -EnvironmentName $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName
+        $ConnectionParams['TenantId'] = $Script:MSCloudLoginConnectionProfile.Teams.TenantId
         Add-MSCloudLoginAssistantEvent -Message 'Disconnecting from Microsoft Teams' -Source $source
         Disconnect-MicrosoftTeams | Out-Null
 

--- a/Tests/Unit/MSCloudLoginAssistant/AuthTokenFlows.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/AuthTokenFlows.Tests.ps1
@@ -173,7 +173,10 @@ Describe 'Get-AuthToken device code flow' {
                 {
                     return @{ device_code = 'device-code'; interval = 0; message = 'Sign in please' }
                 }
-                throw 'the remote name could not be resolved'
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new('the remote name could not be resolved'), 'ConnectionFailure', 'NotSpecified', $null)
+                $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('the remote name could not be resolved')
+                throw $errorRecord
             }
 
             { Get-AuthToken -AuthorizationUrl 'https://login.microsoftonline.com' `

--- a/Tests/Unit/MSCloudLoginAssistant/ConnectionFailures.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/ConnectionFailures.Tests.ps1
@@ -481,7 +481,7 @@ Describe 'Connect-MSCloudLoginTeams failure handling' {
 
     It 'Should keep an existing connection when the session probe returns nothing usable' {
         InModuleScope 'MSCloudLoginAssistant' {
-            Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { return $null }
+            Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $true }
             Mock -CommandName Connect-MicrosoftTeams -MockWith { }
 
             $Script:MSCloudLoginConnectionProfile.Teams.CompleteConnection()

--- a/Tests/Unit/MSCloudLoginAssistant/ConnectionProfile.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/ConnectionProfile.Tests.ps1
@@ -1,0 +1,214 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $graphModuleName = 'Microsoft.Graph.Beta.Identity.DirectoryManagement'
+    if (-not (Get-Module -Name $graphModuleName -ListAvailable))
+    {
+        $script:tempModuleBase = Join-Path $env:TEMP 'MSCloudLoginTestModules'
+        $tempModuleDir = Join-Path $script:tempModuleBase $graphModuleName
+        if (-not (Test-Path $tempModuleDir))
+        {
+            New-Item -Path $tempModuleDir -ItemType Directory -Force | Out-Null
+        }
+        $manifestPath = Join-Path $tempModuleBase "$graphModuleName.psd1"
+        if (-not (Test-Path $manifestPath))
+        {
+            New-ModuleManifest -Path $manifestPath -ModuleVersion '1.0.0' -Description 'Test stub'
+        }
+        $env:PSModulePath = $script:tempModuleBase + [IO.Path]::PathSeparator + $env:PSModulePath
+    }
+
+    Import-Module (Join-Path $PSScriptRoot '..\Stubs\Stubs.psm1') -Force -Global -WarningAction SilentlyContinue
+    $script:moduleRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..\..\Modules\MSCloudLoginAssistant')
+    Import-Module (Join-Path $script:moduleRoot 'MSCloudLoginAssistant.psd1') -Force
+}
+
+AfterAll {
+    if ($script:tempModuleBase -and (Test-Path $script:tempModuleBase))
+    {
+        Remove-Item -Path $script:tempModuleBase -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'PnP constructor validation' {
+
+    It 'Should refuse a certificate thumbprint combined with a certificate path' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            # Property initializers run before the base constructor body, which lets us
+            # instantiate the class with both certificate options already populated.
+            # The class keyword resolves base types at parse time, so the derived class
+            # must be compiled at runtime, after the module types became available.
+            $derivedClassDefinition = @'
+class PnPWithConflictingCertificate : PnP
+{
+    [string]$CertificateThumbprint = 'AA11BB22CC33DD44EE55FF6677889900AABBCCDD'
+    [string]$CertificatePath = "$env:TEMP\contoso.pfx"
+}
+'@
+            . ([scriptblock]::Create($derivedClassDefinition))
+
+            { [PnPWithConflictingCertificate]::new() } |
+                Should -Throw '*Cannot specify both a Certificate Thumbprint and Certificate Path and Password*'
+        }
+    }
+
+    It 'Should allow an instance without conflicting certificate settings' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            { [PnP]::new() } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'PnP sovereign cloud environment translation' {
+
+    BeforeEach {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:MSCloudLoginConnectionProfile = $null
+            $Script:MSCloudLoginTriedGetEnvironment = $true
+            $Script:CloudEnvironmentInfo = $null
+        }
+    }
+
+    It 'Should translate <EnvironmentName> into the <ExpectedPnPEnvironment> PnP environment' -TestCases @(
+        @{ EnvironmentName = 'AzureFranceCloud'; ExpectedPnPEnvironment = 'BleuCloud'; Discovery = '{ "tenant_region_scope": "FG", "token_endpoint": "https://login.sovcloud-identity.fr/t/oauth2/v2.0/token" }' }
+        @{ EnvironmentName = 'AzureGermanyCloud'; ExpectedPnPEnvironment = 'DelosCloud'; Discovery = '{ "tenant_region_scope": "GG2", "token_endpoint": "https://login.sovcloud-identity.de/t/oauth2/v2.0/token" }' }
+    ) {
+        param ($EnvironmentName, $ExpectedPnPEnvironment, $Discovery)
+        InModuleScope 'MSCloudLoginAssistant' -Parameters @{
+            EnvironmentName        = $EnvironmentName
+            ExpectedPnPEnvironment = $ExpectedPnPEnvironment
+            Discovery              = $Discovery
+        } {
+            param ($EnvironmentName, $ExpectedPnPEnvironment, $Discovery)
+
+            Mock -CommandName Import-Module -MockWith { }
+            Mock -CommandName Connect-PnPOnline -MockWith { }
+            Mock -CommandName Get-PnPContext -MockWith { throw 'no context yet' }
+
+            $Script:CloudEnvironmentInfo = ConvertFrom-Json $Discovery
+
+            Connect-M365Tenant -Workload 'PnP' `
+                -Url 'https://contoso-admin.sharepoint.com' `
+                -ApplicationId '11111111-1111-1111-1111-111111111111' `
+                -TenantId 'contoso.onmicrosoft.com' `
+                -CertificateThumbprint 'AA11BB22CC33DD44EE55FF6677889900AABBCCDD'
+
+            $connection = Get-MSCloudLoginConnectionProfile -Workload 'PnP'
+            $connection.EnvironmentName | Should -Be $EnvironmentName
+            $connection.PnPAzureEnvironment | Should -Be $ExpectedPnPEnvironment
+            Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                $AzureEnvironment -eq $ExpectedPnPEnvironment
+            }
+        }
+    }
+}
+
+Describe 'MicrosoftTeams sovereign cloud environment registration' {
+
+    BeforeEach {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:MSCloudLoginConnectionProfile = $null
+            $Script:MSCloudLoginTriedGetEnvironment = $true
+            $Script:CloudEnvironmentInfo = $null
+        }
+    }
+
+    AfterEach {
+        InModuleScope 'MSCloudLoginAssistant' -Parameters @{ ModuleRoot = $script:moduleRoot } {
+            param ($ModuleRoot)
+
+            # Teams.Connect() writes into the shared custom environment configuration.
+            $Script:CustomEnvConfig = Import-PowerShellDataFile -Path (Join-Path $ModuleRoot 'CustomEnvironment.psd1')
+            $Script:LoadedCustomEnvFileName = 'CustomEnvironment.psd1'
+        }
+    }
+
+    It 'Should register the German sovereign endpoints and refuse the connection outside of Windows PowerShell 5' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'no session' }
+            Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+            Mock -CommandName Set-TeamsEnvironmentConfig -MockWith { }
+
+            $Script:CloudEnvironmentInfo = ConvertFrom-Json '{ "tenant_region_scope": "GG2", "token_endpoint": "https://login.sovcloud-identity.de/t/oauth2/v2.0/token" }'
+
+            { Connect-M365Tenant -Workload 'MicrosoftTeams' `
+                -ApplicationId '11111111-1111-1111-1111-111111111111' `
+                -TenantId 'contoso.onsovcloud.de' `
+                -CertificateThumbprint 'AA11BB22CC33DD44EE55FF6677889900AABBCCDD' } |
+                Should -Throw '*only supported in PowerShell 5*'
+
+            $connection = Get-MSCloudLoginConnectionProfile -Workload 'MicrosoftTeams'
+            $connection.EnvironmentName | Should -Be 'AzureGermanyCloud'
+            $connection.AuthorizationUrl | Should -Be 'https://login.sovcloud-identity.de/'
+            $Script:CustomEnvConfig.CustomTeamsEndpoints.ActiveDirectory | Should -Be 'https://login.sovcloud-identity.de/'
+            $Script:CustomEnvConfig.CustomTeamsEndpoints.MsGraphEndpointResourceId | Should -Be 'https://graph.svc.sovcloud.de'
+            $Script:CustomEnvConfig.CustomTeamsEndpoints.TeamsConfigApiEndPoint | Should -Be 'https://config.teams.sovcloud.de'
+            Should -Invoke Set-TeamsEnvironmentConfig -Exactly 0
+        }
+    }
+}
+
+Describe 'SharePointOnlineREST connection logic' {
+
+    BeforeEach {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:MSCloudLoginTriedGetEnvironment = $true
+            $Script:CloudEnvironmentInfo = $null
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+
+            # Configure the stored profile so that Connect() can discover the admin URL,
+            # then invoke Connect() on a separate instance to observe how the discovered
+            # URL is adopted from the profile.
+            $storedProfile = $Script:MSCloudLoginConnectionProfile.SharePointOnlineREST
+            $storedProfile.AuthenticationType = 'ServicePrincipalWithSecret'
+            $storedProfile.RequestedAuthenticationType = 'ServicePrincipalWithSecret'
+            $storedProfile.ApplicationId = '11111111-1111-1111-1111-111111111111'
+            $storedProfile.ApplicationSecret = 'super-secret'
+            $storedProfile.TenantId = 'contoso.onmicrosoft.com'
+        }
+    }
+
+    AfterEach {
+        InModuleScope 'MSCloudLoginAssistant' -Parameters @{ ModuleRoot = $script:moduleRoot } {
+            param ($ModuleRoot)
+            $Script:CustomEnvConfig = Import-PowerShellDataFile -Path (Join-Path $ModuleRoot 'CustomEnvironment.psd1')
+            $Script:LoadedCustomEnvFileName = 'CustomEnvironment.psd1'
+        }
+    }
+
+    It 'Should adopt the admin URL that was discovered through the tenant id' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Connect-MSCloudLoginSharePointOnlineREST -MockWith { }
+
+            $workload = [SharePointOnlineREST]::new()
+            $workload.RequestedAuthenticationType = 'ServicePrincipalWithSecret'
+            $workload.Connect()
+
+            $workload.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            $workload.HostUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            $workload.Scope | Should -Be 'https://contoso-admin.sharepoint.com/.default'
+            $workload.AuthorizationUrl | Should -Be 'https://login.microsoftonline.com'
+            Should -Invoke Connect-MSCloudLoginSharePointOnlineREST -Exactly 1
+        }
+    }
+
+    It 'Should derive the scope from the custom host URL' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:CustomEnvConfig.CustomEnvironment = $true
+            Mock -CommandName Connect-MSCloudLoginSharePointOnlineREST -MockWith { }
+
+            $workload = [SharePointOnlineREST]::new()
+            $workload.RequestedAuthenticationType = 'ServicePrincipalWithSecret'
+            $workload.Connect()
+
+            $workload.EnvironmentName | Should -Be 'Custom'
+            $workload.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            $workload.HostUrl | Should -Be 'https://customdomain.sharepoint.com'
+            $workload.AuthorizationUrl | Should -Be 'https://login.microsoftonline.com'
+            # The custom configuration defines no dedicated scope key, so the class
+            # derives the scope from the resolved host URL.
+            $workload.Scope | Should -Be 'https://customdomain.sharepoint.com/.default'
+            Should -Invoke Connect-MSCloudLoginSharePointOnlineREST -Exactly 1
+        }
+    }
+}

--- a/Tests/Unit/MSCloudLoginAssistant/EndToEndSessionWorkloads.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/EndToEndSessionWorkloads.Tests.ps1
@@ -671,7 +671,16 @@ Describe 'Connect-M365Tenant end-to-end for Microsoft Teams' {
     Context 'When a Teams session is still usable' {
         It 'Should reuse the session without calling Connect-MicrosoftTeams' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { return @{ Identity = 'Global' } }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Get-MSCloudLoginAccessToken -MockWith { return 'access-token' }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                Connect-M365Tenant -Workload 'MicrosoftTeams' `
+                    -ApplicationId '11111111-1111-1111-1111-111111111111' `
+                    -TenantId 'contoso.onmicrosoft.com' `
+                    -CertificateThumbprint 'AA11BB22CC33DD44EE55FF6677889900AABBCCDD'
+
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $true }
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
 
                 Connect-M365Tenant -Workload 'MicrosoftTeams' `
@@ -680,7 +689,7 @@ Describe 'Connect-M365Tenant end-to-end for Microsoft Teams' {
                     -CertificateThumbprint 'AA11BB22CC33DD44EE55FF6677889900AABBCCDD'
 
                 (Get-MSCloudLoginConnectionProfile -Workload 'MicrosoftTeams').Connected | Should -BeTrue
-                Should -Invoke Connect-MicrosoftTeams -Exactly 0
+                Should -Invoke Connect-MicrosoftTeams -Exactly 1
             }
         }
     }

--- a/Tests/Unit/MSCloudLoginAssistant/ExchangeOnline.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/ExchangeOnline.Tests.ps1
@@ -247,7 +247,7 @@ Context 'When connecting with AccessTokens' {
                 try
                 {
                     $PSVersionTable['Platform'] = 'Unix'
-                    $PSVersionTable['PSVersion'] = [System.Version]'7.4.0'
+                    $PSVersionTable['PSVersion'] = [System.Version]'7.6.0'
 
                     { Connect-MSCloudLoginExchangeOnline } |
                         Should -Throw '*Certificate Thumbprint authentication is only supported on the Windows platform*'

--- a/Tests/Unit/MSCloudLoginAssistant/ExchangeOnline.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/ExchangeOnline.Tests.ps1
@@ -148,6 +148,154 @@ Context 'When connecting with AccessTokens' {
             }
         }
     }
+
+    Context 'When connecting with ServicePrincipalWithPath' {
+        It 'Should connect when the session is elevated and derive the organization from the tenant id' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-ExchangeOnline -MockWith { }
+                Mock -CommandName Get-ConnectionInformation -MockWith { return @() }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Remove-MSCloudLoginProxyModule -MockWith { }
+                Mock -CommandName Disconnect-ExchangeOnline -MockWith { }
+                Mock -CommandName Get-MSCloudLoginWindowsPrincipal -MockWith {
+                    # A generic principal whose role list answers IsInRole without
+                    # depending on the privileges of the test runner.
+                    [System.Security.Principal.GenericPrincipal]::new(
+                        [System.Security.Principal.GenericIdentity]::new('test-user'),
+                        [System.String[]]@('Administrator'))
+                }
+
+                $certificatePassword = ConvertTo-SecureString 'cert-password' -AsPlainText -Force
+                $Script:MSCloudLoginCurrentLoadedModule = ''
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.AuthenticationType = 'ServicePrincipalWithPath'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CertificatePath = 'C:\certs\contoso.pfx'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CertificatePassword = $certificatePassword
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ExchangeEnvironmentName = 'O365Default'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+
+                Connect-MSCloudLoginExchangeOnline
+
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected | Should -BeTrue
+                $Script:MSCloudLoginConnectionProfile.OrganizationName | Should -Be 'contoso.onmicrosoft.com'
+                Should -Invoke Connect-ExchangeOnline -Exactly 1 -ParameterFilter {
+                    $AppId -eq 'app-id' -and
+                    $Organization -eq 'contoso.onmicrosoft.com' -and
+                    $CertificateFilePath -eq 'C:\certs\contoso.pfx' -and
+                    $CertificatePassword -is [System.Security.SecureString]
+                }
+            }
+        }
+
+        It 'Should refuse an unelevated session and leave the workload disconnected' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-ExchangeOnline -MockWith { }
+                Mock -CommandName Get-ConnectionInformation -MockWith { return @() }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Remove-MSCloudLoginProxyModule -MockWith { }
+                Mock -CommandName Disconnect-ExchangeOnline -MockWith { }
+                Mock -CommandName Get-MSCloudLoginWindowsPrincipal -MockWith {
+                    [System.Security.Principal.GenericPrincipal]::new(
+                        [System.Security.Principal.GenericIdentity]::new('test-user'),
+                        [System.String[]]@('Users'))
+                }
+
+                $Script:MSCloudLoginCurrentLoadedModule = ''
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.AuthenticationType = 'ServicePrincipalWithPath'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CertificatePath = 'C:\certs\contoso.pfx'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CertificatePassword = ConvertTo-SecureString 'cert-password' -AsPlainText -Force
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ExchangeEnvironmentName = 'O365Default'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+
+                { Connect-MSCloudLoginExchangeOnline } | Should -Throw '*requires the command to be run as Administrator*'
+
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $EntryType -eq 'Error' -and $Message -like '*Failed to connect to Exchange Online with Certificate Path*'
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithThumbprint on a non-Windows platform' {
+        It 'Should refuse certificate thumbprint authentication outside of Windows' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-ExchangeOnline -MockWith { }
+                Mock -CommandName Get-ConnectionInformation -MockWith { return @() }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginCurrentLoadedModule = ''
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.TenantId = 'tenant-id.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ExchangeEnvironmentName = 'O365Default'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+
+                # Simulate a modern PowerShell running on a non-Windows platform.
+                $originalPlatform = $PSVersionTable['Platform']
+                $originalVersion = $PSVersionTable['PSVersion']
+                try
+                {
+                    $PSVersionTable['Platform'] = 'Unix'
+                    $PSVersionTable['PSVersion'] = [System.Version]'7.4.0'
+
+                    { Connect-MSCloudLoginExchangeOnline } |
+                        Should -Throw '*Certificate Thumbprint authentication is only supported on the Windows platform*'
+                }
+                finally
+                {
+                    if ($null -ne $originalPlatform)
+                    {
+                        $PSVersionTable['Platform'] = $originalPlatform
+                    }
+                    if ($null -ne $originalVersion)
+                    {
+                        $PSVersionTable['PSVersion'] = $originalVersion
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'When connecting with CredentialsWithTenantId' {
+        It 'Should surface a non MFA sign-in failure and leave the workload disconnected' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-ExchangeOnline -MockWith { throw 'the account was disabled' }
+                Mock -CommandName Get-ConnectionInformation -MockWith { return @() }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $credential = New-Object PSCredential ('user@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+
+                $Script:MSCloudLoginCurrentLoadedModule = ''
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.AuthenticationType = 'CredentialsWithTenantId'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Credentials = $credential
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.TenantId = 'partner.contoso.com'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.ExchangeEnvironmentName = 'O365Default'
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected = $false
+
+                { Connect-MSCloudLoginExchangeOnline } | Should -Throw '*account was disabled*'
+
+                $Script:MSCloudLoginConnectionProfile.ExchangeOnline.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $EntryType -eq 'Error' -and $Message -like '*Failed to connect to Exchange Online with Credentials and TenantId*'
+                }
+            }
+        }
+    }
 }
 
 Describe 'Disconnect-MSCloudLoginExchangeOnline' {
@@ -178,6 +326,20 @@ Describe 'Disconnect-MSCloudLoginExchangeOnline' {
 
                 { Disconnect-MSCloudLoginExchangeOnline } | Should -Not -Throw
             }
+        }
+    }
+}
+
+Describe 'Get-MSCloudLoginWindowsPrincipal' {
+    BeforeAll {
+        Import-Module ./Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1 -Force
+    }
+
+    It 'Should return the principal of the current Windows user' -Skip:(-not $IsWindows) {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $principal = Get-MSCloudLoginWindowsPrincipal
+            $principal | Should -BeOfType [System.Security.Principal.WindowsPrincipal]
+            $principal.Identity.Name | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Auth.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Auth.Tests.ps1
@@ -137,6 +137,38 @@ Describe 'Get-AuthToken' {
                     Should -Throw '*Unable to determine the Azure Arc managed identity secret file*'
             }
         }
+
+        It 'Should retrieve the token after obtaining the challenge secret file' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $env:AZUREPS_HOST_ENVIRONMENT = ''
+                $env:IDENTITY_ENDPOINT = 'http://localhost:40342/metadata/identity/oauth2/token'
+                $env:IDENTITY_HEADER = ''
+                $env:IMDS_ENDPOINT = 'http://localhost:40342'
+
+                $script:arcCallCount = 0
+                Mock -CommandName Invoke-WebRequest -MockWith {
+                    $script:arcCallCount++
+                    if ($script:arcCallCount -eq 1)
+                    {
+                        # First request throws with a WWW-Authenticate challenge header
+                        # pointing at the secret file.
+                        $ex = [System.Exception]::new('401 Unauthorized')
+                        $response = [PSCustomObject]@{
+                            Headers = @{ 'WWW-Authenticate' = 'Basic realm=C:\secrets\arc-secret' }
+                        }
+                        $ex | Add-Member -NotePropertyName Response -NotePropertyValue $response -Force
+                        throw $ex
+                    }
+                    return [PSCustomObject]@{
+                        Content = '{ "access_token": "arc-token" }'
+                    }
+                }
+                Mock -CommandName Get-Content -MockWith { return 'arc-secret-value' }
+
+                $result = Get-AuthToken -Identity -Resource 'https://graph.microsoft.com'
+                $result | Should -Be 'arc-token'
+            }
+        }
     }
 
     Context 'When using a client secret' {

--- a/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Core.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Core.Tests.ps1
@@ -90,6 +90,58 @@ Describe 'Add-MSCloudLoginAssistantEvent' {
             }
         }
     }
+
+    Context 'When event log writing is enabled' {
+        BeforeAll {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:WriteToEventLog = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:WriteToEventLog = $false
+            }
+        }
+
+        It 'Should detect the source exists on a different log and emit a warning' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Write-Warning -MockWith { }
+                Mock -CommandName Write-Verbose -MockWith { }
+
+                # 'Application' is a well-known source on the Application log,
+                # which differs from 'MSCloudLoginAssistant'. This hits the warning path.
+                Add-MSCloudLoginAssistantEvent -Message 'Log message' -Source 'Application'
+
+                Should -Invoke Write-Warning -ParameterFilter {
+                    $Message -like '[[]ERROR[]] Specified source {Application} already exists on log*'
+                }
+            }
+        }
+
+        It 'Should attempt to create a new event source for an unknown source name' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Write-Warning -MockWith { }
+                Mock -CommandName Write-Verbose -MockWith { }
+
+                # Use a source name that does not exist.
+                # CreateEventSource will throw SecurityException (not admin),
+                # which is caught and logged at the verbose level.
+                { Add-MSCloudLoginAssistantEvent -Message 'Log message' -Source ('MSCloudLoginTest.Coverage.' + [guid]::NewGuid().ToString('N')) } | Should -Not -Throw
+            }
+        }
+
+        It 'Should truncate a message that exceeds 32766 characters' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Write-Warning -MockWith { }
+                Mock -CommandName Write-Verbose -MockWith { }
+
+                $longMessage = 'A' * 40000
+
+                { Add-MSCloudLoginAssistantEvent -Message $longMessage -Source 'Application' } | Should -Not -Throw
+            }
+        }
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/MSCloudLoginAssistant.Tests.ps1
@@ -1128,6 +1128,23 @@ Describe 'Reset-MSCloudLoginConnectionProfileContext' {
             }
         }
     }
+
+    Context 'When a workload has no Disconnect method' {
+        It 'Should log that the operation was ignored' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Get-Member -MockWith { return $null } -ParameterFilter {
+                    $Name -eq 'Disconnect'
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                Reset-MSCloudLoginConnectionProfileContext -Workload 'AdminAPI'
+
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like 'No disconnect method found for workload {AdminAPI}*'
+                }
+            }
+        }
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -1195,6 +1212,254 @@ Describe 'Connect-MSCloudLoginSecurityCompliance' {
                 $Script:MSCloudLoginConnectionProfile.SecurityComplianceCenter.AuthenticationType = 'Interactive'
 
                 { Connect-MSCloudLoginSecurityCompliance } | Should -Throw "*is not supported for workload 'SecurityComplianceCenter'*"
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Compare-InputParametersForChange with MicrosoftTeams / PowerPlatforms mapping
+# ---------------------------------------------------------------------------
+Describe 'Compare-InputParametersForChange workload name mapping' {
+
+    BeforeAll {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+        }
+    }
+
+    Context 'When the workload is MicrosoftTeams' {
+        It 'Should map to Teams and compare correctly' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.Teams.RequestedAuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumb'
+
+                $params = @{
+                    Workload              = 'MicrosoftTeams'
+                    ApplicationId         = 'app-id'
+                    TenantId              = 'tenant-id'
+                    CertificateThumbprint = 'thumb'
+                }
+                (Compare-InputParametersForChange -CurrentParamSet $params) | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'When the workload is PowerPlatforms' {
+        It 'Should map to PowerPlatform and compare correctly' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PowerPlatform.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PowerPlatform.RequestedAuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PowerPlatform.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PowerPlatform.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.PowerPlatform.CertificateThumbprint = 'thumb'
+
+                $params = @{
+                    Workload              = 'PowerPlatforms'
+                    ApplicationId         = 'app-id'
+                    TenantId              = 'tenant-id'
+                    CertificateThumbprint = 'thumb'
+                }
+                (Compare-InputParametersForChange -CurrentParamSet $params) | Should -BeFalse
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Assert-IsNonInteractiveShell non-interactive path
+# ---------------------------------------------------------------------------
+Describe 'Assert-IsNonInteractiveShell non-interactive' {
+
+    It 'Should return $true when UserInteractive is $false' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            # Cannot directly mock [Environment]::UserInteractive, so we test the
+            # reverse: when powershell is running with -NonInteractive, the function
+            # picks it up from command-line arguments.
+            # In the Pester test runner context, this is typically interactive.
+            # We test the logic by observing that the function handles its inputs correctly.
+            (Assert-IsNonInteractiveShell) -is [System.Boolean] | Should -BeTrue
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Connect-M365Tenant PnP URL handling
+# ---------------------------------------------------------------------------
+Describe 'Connect-M365Tenant PnP URL handling' {
+
+    BeforeAll {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+            Mock -CommandName Import-Module -MockWith { }
+            Mock -CommandName Get-MSCloudLoginCertificate -MockWith {
+                return New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+            }
+            Mock -CommandName Get-CloudEnvironmentInfo -MockWith {
+                return @{ tenant_region_sub_scope = $null; token_endpoint = 'https://login.microsoftonline.com/t/oauth2/v2.0/token' }
+            }
+            Mock -CommandName Connect-MSCloudLoginPnP -MockWith { }
+            Mock -CommandName Connect-PnPOnline -MockWith { }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Get-Module -MockWith {
+                if ($ListAvailable.IsPresent -and $Name -eq 'PnP.PowerShell') {
+                    return @([PSCustomObject]@{ Name = 'PnP.PowerShell'; Version = [System.Version]'1.10.0'; CompatiblePSEditions = @('Desktop', 'Core') })
+                }
+                return @()
+            }
+            Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                return @{ ConnectionUrl = 'https://contoso.sharepoint.com'; AdminUrl = 'https://contoso-admin.sharepoint.com' }
+            }
+        }
+    }
+
+    Context 'When connecting to PnP for the first time with a URL' {
+        It 'Should set the AdminUrl from the provided URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                Connect-M365Tenant -Workload 'PnP' `
+                    -Url 'https://contoso-admin.sharepoint.com' `
+                    -ApplicationId 'app-id' -TenantId 'tenant-id' `
+                    -CertificateThumbprint 'thumb'
+
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            }
+        }
+    }
+
+    Context 'When connecting to PnP without a URL after AdminUrl is set' {
+        It 'Should use AdminUrl and handle context mismatch' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Get-PnPContext -MockWith {
+                    return @{ Url = 'https://contoso.sharepoint.com/sites/marketing' }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumb'
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.RequestedAuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected = $true
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectedDateTime = [System.DateTime]::Now.ToString()
+
+                Connect-M365Tenant -Workload 'PnP' `
+                    -ApplicationId 'app-id' -TenantId 'tenant-id' `
+                    -CertificateThumbprint 'thumb'
+
+                # ConnectionUrl should be back to AdminUrl after context mismatch
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Get-CloudEnvironmentInfo sovcloud paths
+# ---------------------------------------------------------------------------
+Describe 'Get-CloudEnvironmentInfo sovcloud' {
+
+    BeforeAll {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+        }
+    }
+
+    Context 'When the tenant is in the German sovereign cloud' {
+        It 'Should resolve the sovcloud identity endpoint' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Invoke-WebRequest -MockWith {
+                    return @{ Content = '{ "tenant_region_sub_scope": "EU", "token_endpoint": "https://login.sovcloud-identity.de/t/oauth2/v2.0/token" }' }
+                }
+
+                $result = Get-CloudEnvironmentInfo -TenantId 'contoso.onsovcloud.de'
+                $result.tenant_region_sub_scope | Should -Be 'EU'
+                Should -Invoke Invoke-WebRequest -ParameterFilter {
+                    $Uri -like 'https://login.sovcloud-identity.de/*'
+                }
+            }
+        }
+    }
+
+    Context 'When the tenant is in the French sovereign cloud' {
+        It 'Should resolve the sovcloud identity endpoint' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Invoke-WebRequest -MockWith {
+                    return @{ Content = '{ "tenant_region_sub_scope": "EU", "token_endpoint": "https://login.sovcloud-identity.fr/t/oauth2/v2.0/token" }' }
+                }
+
+                $result = Get-CloudEnvironmentInfo -TenantId 'contoso.onsovcloud.fr'
+                $result.tenant_region_sub_scope | Should -Be 'EU'
+                Should -Invoke Invoke-WebRequest -ParameterFilter {
+                    $Uri -like 'https://login.sovcloud-identity.fr/*'
+                }
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Get-SPOAdminUrl with Credential parameter
+# ---------------------------------------------------------------------------
+Describe 'Get-SPOAdminUrl with credential' {
+
+    BeforeAll {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+            Mock -CommandName Connect-M365Tenant -MockWith { }
+        }
+    }
+
+    Context 'When credentials are provided' {
+        It 'Should pass the credential through to Connect-M365Tenant' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $cred = New-Object PSCredential ('user@contoso.com', (ConvertTo-SecureString 'pwd' -AsPlainText -Force))
+                Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                    return @{ webUrl = 'https://contoso.sharepoint.com' }
+                }
+                $result = Get-SPOAdminUrl -Credential $cred
+                $result | Should -Be 'https://contoso-admin.sharepoint.com'
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Custom environment reload in Connect-M365Tenant
+# ---------------------------------------------------------------------------
+Describe 'Connect-M365Tenant custom environment reload' {
+
+    BeforeAll {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+            Mock -CommandName Connect-MSCloudLoginAdminAPI -MockWith { }
+            Mock -CommandName Import-PowerShellDataFile -MockWith {
+                return @{ CustomEnvironment = $false }
+            }
+        }
+    }
+
+    Context 'When the custom environment file name changes' {
+        It 'Should reload the custom environment configuration' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                # Clear the module-level config to force a reload
+                $Script:CustomEnvConfig = $null
+
+                Connect-M365Tenant -Workload 'AdminAPI' `
+                    -ApplicationId 'app-id' -TenantId 'tenant-id' -ApplicationSecret 'secret' `
+                    -CustomEnvironmentFileName 'OtherEnvironment.psd1'
+
+                $Script:LoadedCustomEnvFileName | Should -Be 'OtherEnvironment.psd1'
+                Should -Invoke Import-PowerShellDataFile -ParameterFilter {
+                    $Path -like '*OtherEnvironment.psd1'
+                }
             }
         }
     }

--- a/Tests/Unit/MSCloudLoginAssistant/MicrosoftGraph.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/MicrosoftGraph.Tests.ps1
@@ -2,7 +2,17 @@
 
 Describe 'Connect-MSCloudLoginMicrosoftGraph' {
     BeforeAll {
+        # Plain function stubs keep command resolution (and therefore Pester mock
+        # creation) off the real SDK modules, which would otherwise be discovered
+        # and imported on first use at a multi second cost.
+        Import-Module (Join-Path $PSScriptRoot '..\Stubs\Stubs.psm1') -Force -Global -WarningAction SilentlyContinue
         Import-Module ./Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1 -Force
+
+        # Compile and instantiate the workload classes once here so that the cost
+        # does not show up inside the first test of this file.
+        InModuleScope 'MSCloudLoginAssistant' {
+            $null = New-Object MSCloudLoginConnectionProfile
+        }
     }
 
     Context 'When connecting with Credentials' {
@@ -48,6 +58,7 @@ Describe 'Connect-MSCloudLoginMicrosoftGraph' {
         It 'Should call Connect-MgGraph with AccessToken' {
             InModuleScope 'MSCloudLoginAssistant' {
                 Mock -CommandName Connect-MgGraph -MockWith { }
+                Mock -CommandName Get-MgContext -MockWith { return @{ TenantId = 'context-tenant-id' } }
                 Mock -CommandName Get-AuthToken -MockWith { return 'access-token' }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
@@ -60,9 +71,16 @@ Describe 'Connect-MSCloudLoginMicrosoftGraph' {
 
                 Connect-MSCloudLoginMicrosoftGraph
 
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeTrue
+                # The tenant id must be adopted from the live Graph context.
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId | Should -Be 'context-tenant-id'
+
                 Should -Invoke Connect-MgGraph -ParameterFilter {
                     $AccessToken -ne $null -and
                     $Environment -eq 'Global'
+                }
+                Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                    $Resource -eq 'https://graph.microsoft.com' -and $Identity.IsPresent
                 }
             }
         }
@@ -140,6 +158,597 @@ Describe 'Connect-MSCloudLoginMicrosoftGraph' {
                     $AccessToken -ne $null -and
                     $Environment -eq 'Global'
                 }
+            }
+        }
+    }
+
+    Context 'When an existing Graph context is still valid' {
+        It 'Should reuse the connection instead of connecting again' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MgGraph -MockWith { }
+                Mock -CommandName Connect-MSCloudLoginMSGraphWithUser -MockWith { }
+                Mock -CommandName Get-MgContext -MockWith { return @{ Account = 'admin@contoso.com' } }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
+
+                Connect-MSCloudLoginMicrosoftGraph
+
+                Should -Invoke Connect-MgGraph -Exactly 0
+                Should -Invoke Connect-MSCloudLoginMSGraphWithUser -Exactly 0
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeTrue
+            }
+        }
+
+        It 'Should reconnect when the SDK context is gone' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MgGraph -MockWith { }
+                Mock -CommandName Connect-MSCloudLoginMSGraphWithUser -MockWith { }
+                Mock -CommandName Get-MgContext -MockWith { return $null }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $true
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ConnectedDateTime = [System.DateTime]::Now.ToString()
+
+                Connect-MSCloudLoginMicrosoftGraph
+
+                Should -Invoke Connect-MSCloudLoginMSGraphWithUser -Exactly 1
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'When registering a custom environment' {
+        It 'Should register the custom environment when it does not exist yet' {
+            InModuleScope 'MSCloudLoginAssistant' -Parameters @{ ModuleRoot = (Resolve-Path "$PSScriptRoot\..\..\..\Modules\MSCloudLoginAssistant").Path } {
+                param ($ModuleRoot)
+
+                Mock -CommandName Connect-MSCloudLoginMSGraphWithUser -MockWith { }
+                Mock -CommandName Get-MgEnvironment -MockWith { return @() }
+                Mock -CommandName Add-MgEnvironment -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:CustomEnvConfig.CustomEnvironment = $true
+                try
+                {
+                    $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'Credentials'
+
+                    Connect-MSCloudLoginMicrosoftGraph
+
+                    Should -Invoke Add-MgEnvironment -Exactly 1 -ParameterFilter {
+                        $Name -eq 'Custom' -and
+                        $GraphEndpoint -eq 'https://graph.microsoft.com/' -and
+                        $AzureADEndPoint -eq 'https://login.microsoftonline.com'
+                    }
+                }
+                finally
+                {
+                    $Script:CustomEnvConfig = Import-PowerShellDataFile -Path (Join-Path $ModuleRoot 'CustomEnvironment.psd1')
+                    $Script:LoadedCustomEnvFileName = 'CustomEnvironment.psd1'
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithThumbprint in a custom environment' {
+        It 'Should acquire the token locally and pass it to Connect-MgGraph' {
+            InModuleScope 'MSCloudLoginAssistant' -Parameters @{ ModuleRoot = (Resolve-Path "$PSScriptRoot\..\..\..\Modules\MSCloudLoginAssistant").Path } {
+                param ($ModuleRoot)
+
+                Mock -CommandName Connect-MgGraph -MockWith { }
+                Mock -CommandName Get-MgEnvironment -MockWith { return @([PSCustomObject]@{ Name = 'Custom' }) }
+                Mock -CommandName Add-MgEnvironment -MockWith { }
+                Mock -CommandName Get-MSCloudLoginAccessToken -MockWith { return 'locally-issued-token' }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:CustomEnvConfig.CustomEnvironment = $true
+                try
+                {
+                    $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId = 'app-id'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId = 'contoso.local'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.CertificateThumbprint = 'thumbprint'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment = 'Custom'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Scope = 'https://graph.contoso.local/.default'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TokenUrl = 'https://login.contoso.local/oauth2/v2.0/token'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthorizationUrl = 'https://login.contoso.local'
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+
+                    Connect-MSCloudLoginMicrosoftGraph
+
+                    $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeTrue
+                    Should -Invoke Get-MSCloudLoginAccessToken -Exactly 1 -ParameterFilter {
+                        $ApplicationId -eq 'app-id' -and $TenantId -eq 'contoso.local'
+                    }
+                    Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                        $AccessToken -is [System.Security.SecureString] -and $Environment -eq 'Custom'
+                    }
+                    Should -Invoke Add-MgEnvironment -Exactly 0
+                    Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                        $Message -like '*Successfully connected to the Microsoft Graph API using Certificate Thumbprint*'
+                    }
+                }
+                finally
+                {
+                    $Script:CustomEnvConfig = Import-PowerShellDataFile -Path (Join-Path $ModuleRoot 'CustomEnvironment.psd1')
+                    $Script:LoadedCustomEnvFileName = 'CustomEnvironment.psd1'
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithPath' {
+        It 'Should load the certificate from disk and pass it to Connect-MgGraph' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MgGraph -MockWith { }
+                Mock -CommandName Get-MSCloudLoginCertificate -MockWith { return New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'ServicePrincipalWithPath'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.CertificatePath = 'C:\certs\contoso.pfx'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.CertificatePassword = ConvertTo-SecureString 'cert-password' -AsPlainText -Force
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment = 'Global'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+
+                Connect-MSCloudLoginMicrosoftGraph
+
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeTrue
+                Should -Invoke Get-MSCloudLoginCertificate -ParameterFilter {
+                    $CertificatePath -eq 'C:\certs\contoso.pfx'
+                }
+                Should -Invoke Connect-MgGraph -ParameterFilter {
+                    $TenantId -eq 'tenant-id' -and
+                    $ClientId -eq 'app-id' -and
+                    $Certificate -is [System.Security.Cryptography.X509Certificates.X509Certificate2]
+                }
+            }
+        }
+    }
+
+    Context 'When the authentication type is not supported' {
+        It 'Should throw an error naming the unsupported type' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'Interactive'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+
+                { Connect-MSCloudLoginMicrosoftGraph } |
+                    Should -Throw "*Authentication type 'Interactive' is not supported for workload 'MicrosoftGraph'*"
+            }
+        }
+    }
+
+    Context 'When the connection fails' {
+        It 'Should surface the underlying error and leave the workload disconnected' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MgGraph -MockWith { throw 'the graph tenant is unreachable' }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.AuthenticationType = 'ServicePrincipalWithSecret'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.ApplicationSecret = 'secret'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.GraphEnvironment = 'Global'
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+
+                { Connect-MSCloudLoginMicrosoftGraph } | Should -Throw '*unreachable*'
+
+                $Script:MSCloudLoginConnectionProfile.MicrosoftGraph.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $EntryType -eq 'Error' -and $Message -like '*Failed to connect to Microsoft Graph*'
+                }
+            }
+        }
+    }
+}
+
+Describe 'Connect-MSCloudLoginMSGraphWithUser' {
+
+    It 'Should disconnect the stale account, register the custom environment and connect with the acquired token' {
+        InModuleScope 'MSCloudLoginAssistant' -Parameters @{ ModuleRoot = (Resolve-Path "$PSScriptRoot\..\..\..\Modules\MSCloudLoginAssistant").Path } {
+            param ($ModuleRoot)
+
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Get-MgEnvironment -MockWith { return @([PSCustomObject]@{ Name = 'OtherEnvironment' }) }
+            Mock -CommandName Add-MgEnvironment -MockWith { }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:CustomEnvConfig.CustomEnvironment = $true
+            try
+            {
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+                $graphProfile.Credentials = New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+                $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+                Connect-MSCloudLoginMSGraphWithUser
+
+                $graphProfile.ApplicationId | Should -Be '14d82eec-204b-4c2f-b7e8-296a70dab67e'
+                $graphProfile.AccessTokens | Should -Be 'user-token'
+                $graphProfile.Connected | Should -BeTrue
+
+                Should -Invoke Add-MgEnvironment -Exactly 1 -ParameterFilter {
+                    $Name -eq 'Custom' -and $GraphEndpoint -eq 'https://graph.microsoft.com/'
+                }
+                Should -Invoke Disconnect-MgGraph -Exactly 1
+                Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                    $null -ne $Credentials -and $ClientId -eq '14d82eec-204b-4c2f-b7e8-296a70dab67e'
+                }
+                Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                    $AccessToken -is [System.Security.SecureString] -and $Environment -eq 'Global'
+                }
+            }
+            finally
+            {
+                $Script:CustomEnvConfig = Import-PowerShellDataFile -Path (Join-Path $ModuleRoot 'CustomEnvironment.psd1')
+                $Script:LoadedCustomEnvFileName = 'CustomEnvironment.psd1'
+            }
+        }
+    }
+
+    It 'Should tolerate a failing disconnect of the previous session' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return @{ Account = 'other@contoso.com' } }
+            Mock -CommandName Disconnect-MgGraph -MockWith { throw 'no session to remove' }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Not -Throw
+
+            $graphProfile.Connected | Should -BeTrue
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Disconnecting from Microsoft Graph failed*'
+            }
+        }
+    }
+
+    It 'Should fall back to the device code flow when MFA is required' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { throw 'AADSTS50076: multi-factor authentication is required' }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Connect-MSCloudLoginMSGraphWithUserMFA -MockWith { }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Not -Throw
+
+            Should -Invoke Connect-MSCloudLoginMSGraphWithUserMFA -Exactly 1
+        }
+    }
+
+    It 'Should explain the missing application registration on a bad request in a non interactive shell' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith {
+                throw [System.Net.WebException]::new('System.Net.WebException: The remote server returned an error: (400) Bad Request.')
+            }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $true }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } |
+                Should -Throw "*Unable to retrieve AccessToken. Have you registered the 'Microsoft Graph PowerShell' application already*"
+
+            $graphProfile.Connected | Should -BeFalse
+        }
+    }
+
+    It 'Should reconnect without an environment when the environment specific connect fails' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:microsoftGraphConnectCalls = 0
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+            Mock -CommandName Connect-MgGraph -MockWith {
+                $Script:microsoftGraphConnectCalls++
+                if ($Script:microsoftGraphConnectCalls -eq 1)
+                {
+                    # The first attempt with an explicit environment fails.
+                    throw 'the environment specific endpoint rejected the connection'
+                }
+                # The fallback attempt without an environment succeeds.
+            }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Not -Throw
+
+            $graphProfile.Connected | Should -BeTrue
+            $graphProfile.AccessTokens | Should -Be 'user-token'
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Attempting to connect without specifying the Environment*'
+            }
+            $Script:microsoftGraphConnectCalls | Should -Be 2
+            # The successful retry must be the call that omits the environment.
+            Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                $AccessToken -is [System.Security.SecureString] -and $null -eq $Environment
+            }
+        }
+    }
+
+    It 'Should refuse the interactive fallback in a non interactive session' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $true }
+            Mock -CommandName Connect-MgGraph -MockWith { throw 'token connect failed' }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            # The bare throw in the non-interactive guard re-throws the original
+            # connection failure; the refusal itself is recorded as an error event.
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Throw '*token connect failed*'
+
+            $graphProfile.Connected | Should -BeFalse
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Error connecting*' -and $EntryType -eq 'Error'
+            }
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Unable to connect to Microsoft Graph and interactive fallback is not possible*' -and
+                $EntryType -eq 'Error'
+            }
+        }
+    }
+
+    It 'Should reconnect interactively when both token based attempts fail' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $Script:microsoftGraphConnectCalls = 0
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+            Mock -CommandName Connect-MgGraph -MockWith {
+                $Script:microsoftGraphConnectCalls++
+                if ($Script:microsoftGraphConnectCalls -le 2)
+                {
+                    # Both token based attempts fail; only the interactive sign-in works.
+                    throw 'the token endpoint could not be reached'
+                }
+            }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Not -Throw
+
+            $graphProfile.Connected | Should -BeTrue
+            $graphProfile.MultiFactorAuthentication | Should -BeFalse
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Connecting to Microsoft Graph interactively*'
+            }
+            $Script:microsoftGraphConnectCalls | Should -Be 3
+        }
+    }
+
+    It 'Should recreate the graph context file and retry when saving the context fails' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            $contextDirectory = Join-Path $env:TEMP "opencode\mscloudlogin-graphctx-$PID\.graph"
+            $contextPath = Join-Path $contextDirectory 'GraphContext.json'
+            $Script:graphContextRetryCount = 0
+
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+            Mock -CommandName Connect-MgGraph -MockWith {
+                if ($null -ne $Scopes)
+                {
+                    $Script:graphContextRetryCount++
+                    if (-not (Test-Path -LiteralPath $contextPath))
+                    {
+                        # The first interactive attempt fails because the context file cannot be written.
+                        throw "Failed to save graph context to file at '$contextPath'."
+                    }
+                    return
+                }
+                throw 'the token endpoint could not be reached'
+            }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            New-Item -Path $contextDirectory -ItemType Directory -Force | Out-Null
+            try
+            {
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+                $graphProfile.Credentials =
+                    New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+                $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+                { Connect-MSCloudLoginMSGraphWithUser } | Should -Not -Throw
+
+                Test-Path -LiteralPath $contextPath | Should -BeTrue
+                $Script:graphContextRetryCount | Should -Be 2
+                $graphProfile.Connected | Should -BeTrue
+            }
+            finally
+            {
+                Remove-Item -Path (Split-Path $contextDirectory -Parent) -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Variable -Name graphContextRetryCount -Scope Script -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Should explain the app permissions when the device code terminal timed out' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+            Mock -CommandName Connect-MgGraph -MockWith {
+                if ($null -ne $Scopes)
+                {
+                    throw 'Device code terminal timed-out after 120 seconds. Please try again.'
+                }
+                throw 'the token endpoint could not be reached'
+            }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } |
+                Should -Throw '*Please make sure the app permissions are setup correctly*'
+
+            $graphProfile.Connected | Should -BeFalse
+        }
+    }
+
+    It 'Should surface any other interactive failure and leave the workload disconnected' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-MgContext -MockWith { return $null }
+            Mock -CommandName Disconnect-MgGraph -MockWith { }
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'user-token' } }
+            Mock -CommandName Test-MSCloudLoginMFARequiredError -MockWith { return $false }
+            Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+            Mock -CommandName Connect-MgGraph -MockWith {
+                if ($null -ne $Scopes)
+                {
+                    throw 'sign-in was cancelled by the user'
+                }
+                throw 'the token endpoint could not be reached'
+            }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+
+            { Connect-MSCloudLoginMSGraphWithUser } | Should -Throw '*cancelled by the user*'
+
+            $graphProfile.Connected | Should -BeFalse
+            Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                $Message -like '*Failed to connect to Microsoft Graph interactively*cancelled by the user*' -and
+                $EntryType -eq 'Error'
+            }
+        }
+    }
+}
+
+Describe 'Connect-MSCloudLoginMSGraphWithUserMFA' {
+
+    It 'Should derive the tenant from the credential when no tenant id is set' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'mfa-token' } }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.TenantId = ''
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+
+            Connect-MSCloudLoginMSGraphWithUserMFA
+
+            $graphProfile.Connected | Should -BeTrue
+            $graphProfile.MultiFactorAuthentication | Should -BeTrue
+            $graphProfile.AccessTokens | Should -Be 'mfa-token'
+            Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                $TenantId -eq 'contoso.com' -and $DeviceCode.IsPresent
+            }
+            Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+                $AccessToken -is [System.Security.SecureString] -and $Environment -eq 'Global'
+            }
+        }
+    }
+
+    It 'Should use the tenant id stored on the profile when it is set' {
+        InModuleScope 'MSCloudLoginAssistant' {
+            Mock -CommandName Get-AuthToken -MockWith { return @{ access_token = 'mfa-token' } }
+            Mock -CommandName Connect-MgGraph -MockWith { }
+            Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+
+            $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+            $graphProfile = $Script:MSCloudLoginConnectionProfile.MicrosoftGraph
+            $graphProfile.Credentials =
+                New-Object PSCredential ('admin@contoso.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+            $graphProfile.TenantId = 'contoso.onmicrosoft.com'
+            $graphProfile.Scope = 'https://graph.microsoft.com/.default'
+            $graphProfile.AuthorizationUrl = 'https://login.microsoftonline.com'
+
+            Connect-MSCloudLoginMSGraphWithUserMFA
+
+            Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                $TenantId -eq 'contoso.onmicrosoft.com'
             }
         }
     }

--- a/Tests/Unit/MSCloudLoginAssistant/PnP.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/PnP.Tests.ps1
@@ -2,7 +2,16 @@
 
 Describe 'Connect-MSCloudLoginPnP' {
     BeforeAll {
+        # Plain function stubs keep command resolution off the real SDK modules,
+        # which would otherwise be discovered and imported on first use.
+        Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force -Global -WarningAction SilentlyContinue
         Import-Module ./Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1 -Force
+
+        # Compile and instantiate the workload classes once here so that the cost
+        # does not show up inside the first test of this file.
+        InModuleScope 'MSCloudLoginAssistant' {
+            $null = New-Object MSCloudLoginConnectionProfile
+        }
     }
 
     Context 'When connecting with AccessTokens' {
@@ -46,6 +55,1331 @@ Describe 'Connect-MSCloudLoginPnP' {
                     $Url -eq 'https://contoso-admin.sharepoint.com' -and
                     $AccessToken -eq $secPwd -and
                     $AzureEnvironment -eq 'Production'
+                }
+            }
+        }
+    }
+
+    Context 'When the connection is still reusable' {
+        It 'Should return early without connecting again' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $true }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected = $true
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*Already connected to PnP*'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 0
+            }
+        }
+    }
+
+    Context 'When importing the Graph module as a workaround' {
+        It 'Should log a warning when the import fails' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { throw 'the module could not be loaded' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*Failed to import Microsoft.Graph.Authentication*' -and $EntryType -eq 'Warning'
+                }
+            }
+        }
+    }
+
+    Context 'When loading the PnP.PowerShell module on PowerShell Core' {
+        It 'Should load the Desktop edition through Windows PowerShell when only v1 is available' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name, $ListAvailable)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -ne 'PnP.PowerShell') { return $null }
+                    if (-not $ListAvailable) { return $null }
+                    return @(
+                        [pscustomobject]@{
+                            Name                 = 'PnP.PowerShell'
+                            Version              = [version]'1.10.0'
+                            CompatiblePSEditions = @('Core', 'Desktop')
+                        }
+                    )
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Import-Module -Exactly 1 -ParameterFilter {
+                    $Name -eq 'PnP.PowerShell' -and
+                    $RequiredVersion -eq [version]'1.10.0' -and
+                    $UseWindowsPowerShell.IsPresent
+                }
+            }
+        }
+
+        It 'Should explain that the Windows PowerShell installation is missing when no Desktop edition exists' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name, $ListAvailable)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -ne 'PnP.PowerShell') { return $null }
+                    if (-not $ListAvailable) { return $null }
+                    return @(
+                        [pscustomobject]@{
+                            Name                 = 'PnP.PowerShell'
+                            Version              = [version]'1.10.0'
+                            CompatiblePSEditions = @('Core')
+                        }
+                    )
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } |
+                    Should -Throw '*Powershell 7+ was detected*-UseWindowsPowerShell*not installed for Windows PowerShell*'
+            }
+        }
+
+        It 'Should not reload the module when PnP.PowerShell is already loaded' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name, $ListAvailable)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Import-Module -Exactly 0 -ParameterFilter {
+                    $Name -eq 'PnP.PowerShell'
+                }
+            }
+        }
+    }
+
+    Context 'When resolving the connection URL' {
+        It 'Should adopt the admin URL as connection URL when only the admin URL is set' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+                Should -Invoke Connect-PnPOnline -Exactly 1
+            }
+        }
+
+        It 'Should discover the admin URL through Graph when connecting with credentials' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-SPOAdminUrl -MockWith { return 'https://contoso-admin.sharepoint.com' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Get-SPOAdminUrl -Exactly 1
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Url -eq 'https://contoso-admin.sharepoint.com' -and
+                    $ClientId -eq '9bc3ab49-b65d-410a-85ad-de819febfddc'
+                }
+            }
+        }
+
+        It 'Should fail with a clear message when the admin URL cannot be resolved' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-SPOAdminUrl -MockWith { return '' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+
+                { Connect-MSCloudLoginPnP } | Should -Throw '*Unable to retrieve SharePoint Admin Url*'
+            }
+        }
+
+        It 'Should derive both URLs from the tenant id for non credential authentication' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = 'https://contoso.sharepoint.com'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithSecret'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationSecret = 'secret'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+                Should -Invoke Get-MSCloudLoginSPOUrlFromTenantId -Exactly 1 -ParameterFilter {
+                    $TenantId -eq 'contoso.onmicrosoft.com' -and $EnvironmentName -eq 'AzureCloud'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientSecret -eq 'secret' -and $null -ne $ClientId
+                }
+            }
+        }
+
+        It 'Should backfill the admin URL from an explicit connection URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl | Should -Be 'https://contoso-admin.sharepoint.com'
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithThumbprint' {
+        It 'Should acquire a local token when scope and token URL are configured' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginAccessToken -MockWith { return 'locally-issued-token' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthorizationUrl = 'https://login.contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.Scope = 'https://contoso.sharepoint.com/.default'
+                $Script:MSCloudLoginConnectionProfile.PnP.TokenUrl = 'https://login.contoso.local/oauth2/v2.0/token'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Get-MSCloudLoginAccessToken -Exactly 1 -ParameterFilter {
+                    $ApplicationId -eq 'app-id' -and $CertificateThumbprint -eq 'thumbprint'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $AccessToken -eq 'locally-issued-token'
+                }
+            }
+        }
+
+        It 'Should connect by thumbprint and environment name' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientId -eq 'app-id' -and
+                    $Tenant -eq 'contoso.onmicrosoft.com' -and
+                    $Thumbprint -eq 'thumbprint' -and
+                    $AzureEnvironment -eq 'Production'
+                }
+            }
+        }
+
+        It 'Should pass the custom endpoints when the environment is custom' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.EndPoints = @{
+                    AzureADLoginEndPoint   = 'https://login.contoso.local'
+                    MicrosoftGraphEndPoint = 'https://graph.contoso.local'
+                }
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Custom'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $AzureEnvironment -eq 'Custom' -and
+                    $AzureADLoginEndPoint -eq 'https://login.contoso.local' -and
+                    $MicrosoftGraphEndPoint -eq 'https://graph.contoso.local'
+                }
+            }
+        }
+
+        It 'Should pass the custom endpoints when connecting through the admin URL in a custom environment' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.EndPoints = @{
+                    AzureADLoginEndPoint   = 'https://login.contoso.local'
+                    MicrosoftGraphEndPoint = 'https://graph.contoso.local'
+                }
+                # Leave ConnectionUrl empty so that it is adopted from AdminUrl below.
+                $Script:MSCloudLoginConnectionProfile.PnP.AdminUrl = 'https://contoso-admin.sharepoint.contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Custom'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Url -eq 'https://contoso-admin.sharepoint.contoso.local' -and
+                    $AzureADLoginEndPoint -eq 'https://login.contoso.local'
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithPath' {
+        It 'Should pass the certificate path and password to Connect-PnPOnline' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $certificatePassword = ConvertTo-SecureString 'cert-password' -AsPlainText -Force
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithPath'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificatePath = 'C:\certs\contoso.pfx'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificatePassword = $certificatePassword
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientId -eq 'app-id' -and
+                    $CertificatePath -eq 'C:\certs\contoso.pfx' -and
+                    $CertificatePassword -is [System.Security.SecureString]
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with ServicePrincipalWithSecret' {
+        It 'Should connect with the client secret' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithSecret'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationSecret = 'secret'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientSecret -eq 'secret' -and $Url -eq 'https://contoso-admin.sharepoint.com'
+                }
+            }
+        }
+
+        It 'Should honour a forced refresh even without a connection URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = 'https://contoso.sharepoint.com'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithSecret'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationSecret = 'secret'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP -ForceRefreshConnection:$true } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'When connecting with CredentialsWithTenantId' {
+        It 'Should refuse the combination of credentials and tenant id' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = 'https://contoso.sharepoint.com'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'CredentialsWithTenantId'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+
+                { Connect-MSCloudLoginPnP } |
+                    Should -Throw '*You cannot specify TenantId with Credentials when connecting to PnP*'
+            }
+        }
+    }
+
+    Context 'When connecting with CredentialsWithApplicationId' {
+        It 'Should pass the credential together with the application id' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'CredentialsWithApplicationId'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientId -eq 'app-id' -and $null -ne $Credentials
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with Credentials' {
+        It 'Should connect with the management shell client id' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $null -ne $Credentials -and $ClientId -eq '9bc3ab49-b65d-410a-85ad-de819febfddc'
+                }
+            }
+        }
+    }
+
+    Context 'When connecting with Identity' {
+        It 'Should request a managed identity token for the connection URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-AuthToken -MockWith { return 'managed-identity-token' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Identity'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                    $Resource -eq 'https://contoso-admin.sharepoint.com' -and $Identity.IsPresent
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $AccessToken -eq 'managed-identity-token'
+                }
+            }
+        }
+    }
+
+    Context 'When the authentication type is not supported' {
+        It 'Should throw an error naming the unsupported type' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Interactive'
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } |
+                    Should -Throw "*Authentication type 'Interactive' is not supported for workload 'PnP'*"
+            }
+        }
+    }
+
+    Context 'When the sign-in requires MFA' {
+        It 'Should retry interactively and mark the connection as multi-factor authenticated' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:pnpConnectCalls = 0
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    $Script:pnpConnectCalls++
+                    if ($Script:pnpConnectCalls -eq 1)
+                    {
+                        throw 'AADSTS50076: multi-factor authentication is required'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                $Script:MSCloudLoginConnectionProfile.PnP.MultiFactorAuthentication | Should -BeTrue
+                $Script:pnpConnectCalls | Should -Be 2
+            }
+        }
+
+        It 'Should fall back to the web login when the interactive attempt fails' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:pnpConnectCalls = 0
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    $Script:pnpConnectCalls++
+                    switch ($Script:pnpConnectCalls)
+                    {
+                        1 { throw 'AADSTS50076: multi-factor authentication is required' }
+                        2 { throw 'the interactive window was dismissed' }
+                        default { }
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                $Script:pnpConnectCalls | Should -Be 3
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $UseWebLogin.IsPresent
+                }
+            }
+        }
+
+        It 'Should surface the failure when every fallback fails' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith { throw 'AADSTS50076: multi-factor authentication is required' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $pnpProfile = $Script:MSCloudLoginConnectionProfile.PnP
+                $pnpProfile.AuthenticationType = 'AccessTokens'
+                $pnpProfile.AccessTokens = @('raw-token')
+                $pnpProfile.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Throw '*multi-factor authentication is required*'
+
+                $pnpProfile.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*Failed to connect to PnP interactively after MFA-required error*' -and $EntryType -eq 'Error'
+                }
+            }
+        }
+    }
+
+    Context 'When the credentials are rejected because of MFA' {
+        It 'Should retry interactively on the password mismatch error' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:pnpConnectCalls = 0
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    $Script:pnpConnectCalls++
+                    if ($Script:pnpConnectCalls -eq 1)
+                    {
+                        throw 'The sign-in name or password does not match one in the Microsoft account system.'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                $Script:MSCloudLoginConnectionProfile.PnP.MultiFactorAuthentication | Should -BeTrue
+            }
+        }
+
+        It 'Should surface the failure when the interactive retry also fails' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    throw 'The sign-in name or password does not match one in the Microsoft account system.'
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $pnpProfile = $Script:MSCloudLoginConnectionProfile.PnP
+                $pnpProfile.AuthenticationType = 'Credentials'
+                $pnpProfile.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $pnpProfile.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $pnpProfile.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Throw '*sign-in name or password does not match*'
+
+                $pnpProfile.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*Failed to connect to PnP interactively:*' -and $EntryType -eq 'Error'
+                }
+            }
+        }
+    }
+
+    Context 'When the application has not been consented' {
+        It 'Should register the management shell access and reconnect via web login' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:pnpConnectCalls = 0
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Register-PnPManagementShellAccess -MockWith { }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    $Script:pnpConnectCalls++
+                    if ($Script:pnpConnectCalls -eq 1)
+                    {
+                        throw 'AADSTS65001: The user or administrator has not consented to use the application with ID abc'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Register-PnPManagementShellAccess -Exactly 1
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $UseWebLogin.IsPresent
+                }
+            }
+        }
+
+        It 'Should wrap the error when the consent flow fails' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Register-PnPManagementShellAccess -MockWith { throw 'access denied while registering' }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    throw 'AADSTS65001: The user or administrator has not consented to use the application with ID abc'
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+
+                { Connect-MSCloudLoginPnP } |
+                    Should -Throw "*has not been granted access for this tenant*Register-PnPManagementShellAccess*"
+            }
+        }
+    }
+
+    Context 'When the connection fails for any other reason' {
+        It 'Should surface the underlying error and leave the workload disconnected' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { throw 'the site collection is unavailable' }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $pnpProfile = $Script:MSCloudLoginConnectionProfile.PnP
+                $pnpProfile.AuthenticationType = 'AccessTokens'
+                $pnpProfile.AccessTokens = @('raw-token')
+                $pnpProfile.ConnectionUrl = 'https://contoso-admin.sharepoint.com'
+                $pnpProfile.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Throw '*site collection is unavailable*'
+
+                $pnpProfile.Connected | Should -BeFalse
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*Failed to connect to PnP: *' -and $EntryType -eq 'Error'
+                }
+            }
+        }
+    }
+
+    Context 'When only the admin URL is available after URL resolution' {
+        It 'Should use the tenant GUID instead of the tenant name for AzureChinaCloud' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                # An empty ConnectionUrl in the resolved result leaves the profile
+                # without a connection URL, so the AdminUrl based path applies.
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.cn'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.partner.onmschina.cn'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantGUID = '22222222-2222-2222-2222-222222222222'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureChinaCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'China'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Tenant -eq '22222222-2222-2222-2222-222222222222' -and
+                    $Url -eq 'https://contoso-admin.sharepoint.cn' -and
+                    $AzureEnvironment -eq 'China'
+                }
+            }
+        }
+
+        It 'Should pass the custom endpoints when connecting with a thumbprint through the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.contoso.local'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.local'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificateThumbprint = 'thumbprint'
+                $Script:MSCloudLoginConnectionProfile.PnP.EndPoints = @{
+                    AzureADLoginEndPoint   = 'https://login.contoso.local'
+                    MicrosoftGraphEndPoint = 'https://graph.contoso.local'
+                }
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Custom'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Url -eq 'https://contoso-admin.sharepoint.contoso.local' -and
+                    $AzureADLoginEndPoint -eq 'https://login.contoso.local' -and
+                    $MicrosoftGraphEndPoint -eq 'https://graph.contoso.local'
+                }
+            }
+        }
+
+        It 'Should connect by certificate path through the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithPath'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificatePath = 'C:\certs\contoso.pfx'
+                $Script:MSCloudLoginConnectionProfile.PnP.CertificatePassword =
+                    ConvertTo-SecureString 'cert-password' -AsPlainText -Force
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Url -eq 'https://contoso-admin.sharepoint.com' -and
+                    $CertificatePath -eq 'C:\certs\contoso.pfx'
+                }
+            }
+        }
+
+        It 'Should connect with the client secret through the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'ServicePrincipalWithSecret'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationSecret = 'secret'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*AdminUrl: https://contoso-admin.sharepoint.com*'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientSecret -eq 'secret' -and $Url -eq 'https://contoso-admin.sharepoint.com'
+                }
+            }
+        }
+
+        It 'Should connect with credentials and application id through the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'CredentialsWithApplicationId'
+                $Script:MSCloudLoginConnectionProfile.PnP.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.PnP.Credentials =
+                    New-Object PSCredential ('admin@contoso.onmicrosoft.com', (ConvertTo-SecureString 'p@ssw0rd' -AsPlainText -Force))
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*AdminUrl: https://contoso-admin.sharepoint.com*'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientId -eq 'app-id' -and $null -ne $Credentials -and
+                    $Url -eq 'https://contoso-admin.sharepoint.com'
+                }
+            }
+        }
+
+        It 'Should connect with credentials through the admin URL when the type resolves late' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                # The authentication type flips to Credentials after the URLs have been
+                # resolved, so the connection URL stays empty and the admin URL based
+                # credentials path applies.
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Credentials'
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                Should -Invoke Add-MSCloudLoginAssistantEvent -ParameterFilter {
+                    $Message -like '*using SPOManagementShell and AdminUrl*'
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $ClientId -eq '9bc3ab49-b65d-410a-85ad-de819febfddc' -and
+                    $Url -eq 'https://contoso-admin.sharepoint.com'
+                }
+            }
+        }
+
+        It 'Should request the managed identity token for the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+                Mock -CommandName Get-AuthToken -MockWith { return 'managed-identity-token' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'Identity'
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Get-AuthToken -Exactly 1 -ParameterFilter {
+                    $Resource -eq 'https://contoso-admin.sharepoint.com' -and $Identity.IsPresent
+                }
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $AccessToken -eq 'managed-identity-token'
+                }
+            }
+        }
+
+        It 'Should connect with an access token through the admin URL' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-PnPOnline -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+                Mock -CommandName Get-MSCloudLoginAccessTokenValue -MockWith { return 'resolved-token' }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $AccessToken -eq 'resolved-token' -and
+                    $Url -eq 'https://contoso-admin.sharepoint.com'
+                }
+            }
+        }
+
+        It 'Should retry interactively against the admin URL on the password mismatch error' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $Script:pnpConnectCalls = 0
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+                Mock -CommandName Assert-IsNonInteractiveShell -MockWith { return $false }
+                Mock -CommandName Get-Module -MockWith {
+                    param ($Name)
+                    if ($Name -eq 'Microsoft.Graph.Authentication') { return $null }
+                    if ($Name -eq 'PnP.PowerShell') { return [pscustomobject]@{ Name = 'PnP.PowerShell' } }
+                    return $null
+                }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Get-MSCloudLoginSPOUrlFromTenantId -MockWith {
+                    return @{
+                        AdminUrl      = 'https://contoso-admin.sharepoint.com'
+                        ConnectionUrl = ''
+                    }
+                }
+                Mock -CommandName Get-MSCloudLoginAccessTokenValue -MockWith { return 'resolved-token' }
+                Mock -CommandName Connect-PnPOnline -MockWith {
+                    $Script:pnpConnectCalls++
+                    if ($Script:pnpConnectCalls -eq 1)
+                    {
+                        throw 'The sign-in name or password does not match one in the Microsoft account system.'
+                    }
+                }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.PnP.AuthenticationType = 'AccessTokens'
+                $Script:MSCloudLoginConnectionProfile.PnP.AccessTokens = @('raw-token')
+                $Script:MSCloudLoginConnectionProfile.PnP.TenantId = 'contoso.onmicrosoft.com'
+                $Script:MSCloudLoginConnectionProfile.PnP.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.PnP.PnPAzureEnvironment = 'Production'
+
+                { Connect-MSCloudLoginPnP } | Should -Not -Throw
+
+                $Script:MSCloudLoginConnectionProfile.PnP.Connected | Should -BeTrue
+                $Script:MSCloudLoginConnectionProfile.PnP.MultiFactorAuthentication | Should -BeTrue
+                $Script:pnpConnectCalls | Should -Be 2
+                Should -Invoke Connect-PnPOnline -Exactly 1 -ParameterFilter {
+                    $Interactive.IsPresent -and $Url -eq 'https://contoso-admin.sharepoint.com'
                 }
             }
         }

--- a/Tests/Unit/MSCloudLoginAssistant/Teams.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/Teams.Tests.ps1
@@ -2,13 +2,21 @@
 
 Describe 'Connect-MSCloudLoginTeams' {
     BeforeAll {
+        # Plain function stubs keep command resolution off the real SDK modules,
+        # which would otherwise be discovered and imported on first use.
+        Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force -Global -WarningAction SilentlyContinue
         Import-Module ./Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1 -Force
+
+        # Compile and instantiate the workload classes once here so that the cost
+        # does not show up inside the first test of this file.
+        InModuleScope 'MSCloudLoginAssistant' {
+            $null = New-Object MSCloudLoginConnectionProfile
+        }
     }
 
     Context 'When connecting with ServicePrincipalWithThumbprint' {
         It 'Should call Connect-MicrosoftTeams with AccessTokens' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Get-MSCloudLoginAccessToken -MockWith { return 'access-token' }
@@ -39,10 +47,87 @@ Describe 'Connect-MSCloudLoginTeams' {
         }
     }
 
+    Context 'When connecting with a custom environment' {
+        It 'Should reject custom environment connections outside Windows PowerShell 5' -Skip:($PSVersionTable.PSVersion.Major -eq 5) {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Set-TeamsEnvironmentConfig -MockWith { }
+
+                $originalCustomEnvironment = $Script:CustomEnvConfig.CustomEnvironment
+                $originalCustomTeamsEndpoints = $Script:CustomEnvConfig.CustomTeamsEndpoints
+                try
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $true
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = @{ Teams = 'https://teams.example.test' }
+
+                    $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                    $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                    $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'contoso.onmicrosoft.com'
+                    $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+
+                    { Connect-MSCloudLoginTeams } |
+                        Should -Throw '*only supported in PowerShell 5*'
+
+                    Should -Invoke Set-TeamsEnvironmentConfig -Exactly 0
+                    Should -Invoke Connect-MicrosoftTeams -Exactly 0
+                }
+                finally
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $originalCustomEnvironment
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = $originalCustomTeamsEndpoints
+                }
+            }
+        }
+
+        It 'Should configure and connect through the custom endpoints in Windows PowerShell 5' -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Set-TeamsEnvironmentConfig -MockWith { }
+
+                $originalCustomEnvironment = $Script:CustomEnvConfig.CustomEnvironment
+                $originalCustomTeamsEndpoints = $Script:CustomEnvConfig.CustomTeamsEndpoints
+                try
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $true
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = @{ Teams = 'https://teams.example.test' }
+
+                    $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                    $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                    $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'contoso.onmicrosoft.com'
+                    $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+
+                    Connect-MSCloudLoginTeams
+
+                    $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeTrue
+                    Should -Invoke Set-TeamsEnvironmentConfig -Exactly 1 -ParameterFilter {
+                        $EndpointUris.Teams -eq 'https://teams.example.test'
+                    }
+                    Should -Invoke Connect-MicrosoftTeams -Exactly 1 -ParameterFilter {
+                        $ApplicationId -eq 'app-id' -and
+                        $TenantId -eq 'contoso.onmicrosoft.com' -and
+                        $CertificateThumbprint -eq 'thumbprint'
+                    }
+                }
+                finally
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $originalCustomEnvironment
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = $originalCustomTeamsEndpoints
+                }
+            }
+        }
+    }
+
     Context 'When connecting with ServicePrincipalWithPath' {
         It 'Should call Connect-MicrosoftTeams with CertificatePath' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 $testCert = [Security.Cryptography.X509Certificates.X509Certificate2]::new()
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
@@ -80,7 +165,6 @@ Describe 'Connect-MSCloudLoginTeams' {
     Context 'When connecting with Credentials' {
         It 'Should call Connect-MicrosoftTeams with Credentials' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
@@ -108,7 +192,6 @@ Describe 'Connect-MSCloudLoginTeams' {
     Context 'When MFA is required with Credentials' {
         It 'Should call Connect-MSCloudLoginTeamsMFA' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { throw 'MFA required' }
                 Mock -CommandName Connect-MSCloudLoginTeamsMFA -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
@@ -135,7 +218,6 @@ Describe 'Connect-MSCloudLoginTeams' {
     Context 'When connecting with Identity' {
         It 'Should call Connect-MicrosoftTeams with Identity' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
@@ -157,7 +239,6 @@ Describe 'Connect-MSCloudLoginTeams' {
     Context 'When connecting with AccessTokens' {
         It 'Should call Connect-MicrosoftTeams with AccessTokens' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Get-MSCloudLoginAccessTokenValue -MockWith { return 'token-value' }
@@ -181,7 +262,6 @@ Describe 'Connect-MSCloudLoginTeams' {
     Context 'When unsupported authentication type is provided' {
         It 'Should throw an error' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
                 Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
                 Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
@@ -200,7 +280,6 @@ Describe 'Disconnect-MSCloudLoginTeams' {
     Context 'When Teams is connected' {
         It 'Should call Disconnect-MicrosoftTeams' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Disconnect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
 
@@ -217,7 +296,6 @@ Describe 'Disconnect-MSCloudLoginTeams' {
     Context 'When Teams is not connected' {
         It 'Should not throw and log message' {
             InModuleScope 'MSCloudLoginAssistant' {
-                Import-Module ./Tests/Unit/Stubs/Stubs.psm1 -Force
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
 
                 $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile

--- a/Tests/Unit/MSCloudLoginAssistant/Teams.Tests.ps1
+++ b/Tests/Unit/MSCloudLoginAssistant/Teams.Tests.ps1
@@ -14,8 +14,38 @@ Describe 'Connect-MSCloudLoginTeams' {
         }
     }
 
+    Context 'Get-MSCloudLoginTeamsEnvironmentParameters' {
+        It 'Should return TeamsGCCH for AzureUSGovernment' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $result = Get-MSCloudLoginTeamsEnvironmentParameters -EnvironmentName 'AzureUSGovernment'
+                $result.TeamsEnvironmentName | Should -Be 'TeamsGCCH'
+            }
+        }
+
+        It 'Should return TeamsDOD for USGovernmentDoD' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $result = Get-MSCloudLoginTeamsEnvironmentParameters -EnvironmentName 'USGovernmentDoD'
+                $result.TeamsEnvironmentName | Should -Be 'TeamsDOD'
+            }
+        }
+
+        It 'Should return TeamsDOD for AzureDOD' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $result = Get-MSCloudLoginTeamsEnvironmentParameters -EnvironmentName 'AzureDOD'
+                $result.TeamsEnvironmentName | Should -Be 'TeamsDOD'
+            }
+        }
+
+        It 'Should return TeamsChina for AzureChinaCloud' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                $result = Get-MSCloudLoginTeamsEnvironmentParameters -EnvironmentName 'AzureChinaCloud'
+                $result.TeamsEnvironmentName | Should -Be 'TeamsChina'
+            }
+        }
+    }
+
     Context 'When connecting with ServicePrincipalWithThumbprint' {
-        It 'Should call Connect-MicrosoftTeams with AccessTokens' {
+        It 'Should call Connect-MicrosoftTeams with AccessTokens when GraphScope and TeamsScope are set' {
             InModuleScope 'MSCloudLoginAssistant' {
                 Mock -CommandName Connect-MicrosoftTeams -MockWith { }
                 Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
@@ -34,7 +64,7 @@ Describe 'Connect-MSCloudLoginTeams' {
                 $Script:MSCloudLoginConnectionProfile.Teams.AuthorizationUrl = 'https://login.microsoftonline.com'
                 $Script:MSCloudLoginConnectionProfile.Teams.TokenUrl = 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token'
                 $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
-                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'Custom'
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
                 $Script:CustomEnvConfig.CustomEnvironment = $false
                 $Script:CustomEnvConfig.CustomTeamsEndpoints = $null
 
@@ -43,6 +73,57 @@ Describe 'Connect-MSCloudLoginTeams' {
                 Should -Invoke Connect-MicrosoftTeams -ParameterFilter {
                     $AccessTokens -like '*access-token*'
                 }
+            }
+        }
+
+        It 'Should call Connect-MicrosoftTeams with CertificateThumbprint when GraphScope is not set and not custom env' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumbprint'
+                # Do NOT set GraphScope, TeamsScope, TokenUrl - they default to $null which makes the condition false
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
+                $Script:CustomEnvConfig.CustomEnvironment = $false
+                $Script:CustomEnvConfig.CustomTeamsEndpoints = $null
+
+                Connect-MSCloudLoginTeams
+
+                Should -Invoke Connect-MicrosoftTeams -ParameterFilter {
+                    $ApplicationId -eq 'app-id' -and
+                    $TenantId -eq 'tenant-id' -and
+                    $CertificateThumbprint -eq 'thumbprint'
+                }
+            }
+        }
+
+        It 'Should handle connection failure for ServicePrincipalWithThumbprint (direct Connect-MicrosoftTeams path)' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { throw 'Connection failed' }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumbprint'
+                # Do NOT set GraphScope, TeamsScope, TokenUrl - they default to $null
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
+                $Script:CustomEnvConfig.CustomEnvironment = $false
+                $Script:CustomEnvConfig.CustomTeamsEndpoints = $null
+
+                { Connect-MSCloudLoginTeams } | Should -Throw 'Connection failed'
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeFalse
             }
         }
     }
@@ -123,6 +204,43 @@ Describe 'Connect-MSCloudLoginTeams' {
                 }
             }
         }
+
+        It 'Should call Connect-MicrosoftTeams with CertificateThumbprint in custom environment' -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Set-TeamsEnvironmentConfig -MockWith { }
+
+                $originalCustomEnvironment = $Script:CustomEnvConfig.CustomEnvironment
+                $originalCustomTeamsEndpoints = $Script:CustomEnvConfig.CustomTeamsEndpoints
+                try
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $true
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = @{ Teams = 'https://teams.example.test' }
+
+                    $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                    $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'ServicePrincipalWithThumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.ApplicationId = 'app-id'
+                    $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'contoso.onmicrosoft.com'
+                    $Script:MSCloudLoginConnectionProfile.Teams.CertificateThumbprint = 'thumbprint'
+                    $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+
+                    Connect-MSCloudLoginTeams
+
+                    Should -Invoke Connect-MicrosoftTeams -ParameterFilter {
+                        $ApplicationId -eq 'app-id' -and
+                        $TenantId -eq 'contoso.onmicrosoft.com' -and
+                        $CertificateThumbprint -eq 'thumbprint'
+                    }
+                }
+                finally
+                {
+                    $Script:CustomEnvConfig.CustomEnvironment = $originalCustomEnvironment
+                    $Script:CustomEnvConfig.CustomTeamsEndpoints = $originalCustomTeamsEndpoints
+                }
+            }
+        }
     }
 
     Context 'When connecting with ServicePrincipalWithPath' {
@@ -187,6 +305,28 @@ Describe 'Connect-MSCloudLoginTeams' {
                 }
             }
         }
+
+        It 'Should handle connection failure for Credentials' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { throw 'Invalid credentials' }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Get-CsTeamsCallingPolicy -MockWith { throw 'No session' }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $secPwd = ConvertTo-SecureString 'password' -AsPlainText -Force
+                $cred = New-Object PSCredential ('user@contoso.com', $secPwd)
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.AuthenticationType = 'Credentials'
+                $Script:MSCloudLoginConnectionProfile.Teams.Credentials = $cred
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
+                $Script:CustomEnvConfig.CustomEnvironment = $false
+
+                { Connect-MSCloudLoginTeams } | Should -Throw 'Invalid credentials'
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeFalse
+            }
+        }
     }
 
     Context 'When MFA is required with Credentials' {
@@ -211,6 +351,48 @@ Describe 'Connect-MSCloudLoginTeams' {
                 Connect-MSCloudLoginTeams
 
                 Should -Invoke Connect-MSCloudLoginTeamsMFA
+            }
+        }
+    }
+
+    Context 'Connect-MSCloudLoginTeamsMFA' {
+        It 'Should disconnect existing session and connect with MFA' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Get-MSCloudLoginTeamsEnvironmentParameters -MockWith { return @{} }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Disconnect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+
+                Connect-MSCloudLoginTeamsMFA
+
+                Should -Invoke Disconnect-MicrosoftTeams -Exactly 1
+                Should -Invoke Connect-MicrosoftTeams -Exactly 1
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeTrue
+                $Script:MSCloudLoginConnectionProfile.Teams.MultiFactorAuthentication | Should -BeTrue
+            }
+        }
+
+        It 'Should handle error in MFA path' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Get-MSCloudLoginTeamsEnvironmentParameters -MockWith { return @{} }
+                Mock -CommandName Add-MSCloudLoginAssistantEvent -MockWith { }
+                Mock -CommandName Disconnect-MicrosoftTeams -MockWith { }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { throw 'MFA failed' }
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $false }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.EnvironmentName = 'AzureCloud'
+                $Script:MSCloudLoginConnectionProfile.Teams.TenantId = 'tenant-id'
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
+
+                { Connect-MSCloudLoginTeamsMFA } | Should -Throw 'MFA failed'
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeFalse
             }
         }
     }
@@ -271,6 +453,23 @@ Describe 'Connect-MSCloudLoginTeams' {
                 $Script:MSCloudLoginConnectionProfile.Teams.Connected = $false
 
                 { Connect-MSCloudLoginTeams } | Should -Throw '*not supported for workload*'
+            }
+        }
+    }
+
+    Context 'When session is already usable' {
+        It 'Should reuse existing connection without reconnecting' {
+            InModuleScope 'MSCloudLoginAssistant' {
+                Mock -CommandName Test-MSCloudLoginConnectionReusable -MockWith { return $true }
+                Mock -CommandName Connect-MicrosoftTeams -MockWith { }
+
+                $Script:MSCloudLoginConnectionProfile = New-Object MSCloudLoginConnectionProfile
+                $Script:MSCloudLoginConnectionProfile.Teams.CompleteConnection()
+
+                Connect-MSCloudLoginTeams
+
+                $Script:MSCloudLoginConnectionProfile.Teams.Connected | Should -BeTrue
+                Should -Invoke Connect-MicrosoftTeams -Exactly 0
             }
         }
     }


### PR DESCRIPTION
This PR fixes 2 issues, one in a test how an exception should be thrown instead of a simple string (AuthTokenFlows.Tests.ps1) and the other  to only Disconnect if we are actually connected to ExchangeOnline workload by calling the newly introduced function `Disconnect-MSCloudLoginExchangeOnline` a couple of commits before which now verifies if there's a current connection to EXO before proceeding.

EDIT: Now this also fixes an issue where a Teams connection would be reused into a second tenant even if an attempt to disconnect from the first tenant was made. 